### PR TITLE
Add filtering by file name to backup command

### DIFF
--- a/Ctlg.Service/Commands/BackupCommand.cs
+++ b/Ctlg.Service/Commands/BackupCommand.cs
@@ -7,6 +7,7 @@ namespace Ctlg.Service.Commands
     {
         public string SnapshotName { get; set; }
         public string Path { get; set; }
+        public string SearchPattern { get; set; }
         public bool IsFastMode { get; set; }
 
         public BackupCommand(ITreeProvider treeProvider, ISnapshotWriterProvider snapshotWriterProvider, ISnapshotReader snapshotReader)
@@ -18,7 +19,7 @@ namespace Ctlg.Service.Commands
 
         public void Execute(ICtlgService ctlgService)
         {
-            var root = TreeProvider.ReadTree(Path);
+            var root = TreeProvider.ReadTree(Path, SearchPattern);
 
             if (IsFastMode)
             {

--- a/Ctlg.Service/Commands/FileEnumerateStep.cs
+++ b/Ctlg.Service/Commands/FileEnumerateStep.cs
@@ -12,9 +12,11 @@ namespace Ctlg.Service.Commands
             FilesystemService = filesystemService;
         }
 
-        public File ReadTree(string path)
+        public File ReadTree(string path, string searchPattern = null)
         {
-            var searchPattern = "*";
+            if (string.IsNullOrEmpty(searchPattern)) {
+                searchPattern = "*";
+            }
 
             var di = FilesystemService.GetDirectory(path);
             var root = ParseDirectory(di, searchPattern);

--- a/Ctlg.Service/Commands/ITreeProvider.cs
+++ b/Ctlg.Service/Commands/ITreeProvider.cs
@@ -5,6 +5,6 @@ namespace Ctlg.Service.Commands
 {
     public interface ITreeProvider
     {
-        File ReadTree(string path);
+        File ReadTree(string path, string searchPattern = null);
     }
 }

--- a/Ctlg.UnitTests/BackupCommandTests.cs
+++ b/Ctlg.UnitTests/BackupCommandTests.cs
@@ -75,7 +75,7 @@ namespace Ctlg.UnitTests
         private void SetupTreeProvider(AutoMock mock)
         {
             mock.Mock<ITreeProvider>()
-                .Setup(d => d.ReadTree(It.Is<string>(s => s == "test-path")))
+                .Setup(d => d.ReadTree(It.Is<string>(s => s == "test-path"), It.Is<string>(s => s == null)))
                 .Returns(Tree);
         }
     }

--- a/Ctlg.UnitTests/Ctlg.UnitTests.csproj
+++ b/Ctlg.UnitTests/Ctlg.UnitTests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="MockHelper.cs" />
     <Compile Include="BackupCommandTests.cs" />
     <Compile Include="FileSizeTests.cs" />
+    <Compile Include="FileEnumerateTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Ctlg.UnitTests/Ctlg.UnitTests.csproj
+++ b/Ctlg.UnitTests/Ctlg.UnitTests.csproj
@@ -67,7 +67,7 @@
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.11.0\lib\net45\Moq.dll</HintPath>
+      <HintPath>..\packages\Moq.4.12.0\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Autofac.Extras.Moq">
       <HintPath>..\packages\Autofac.Extras.Moq.4.3.0\lib\net45\Autofac.Extras.Moq.dll</HintPath>
@@ -82,10 +82,10 @@
       <HintPath>..\packages\System.ComponentModel.TypeConverter.4.3.0\lib\net45\System.ComponentModel.TypeConverter.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/Ctlg.UnitTests/FileEnumerateTests.cs
+++ b/Ctlg.UnitTests/FileEnumerateTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Moq;
+using NUnit.Framework;
+using Autofac.Extras.Moq;
+using Ctlg.Core.Interfaces;
+using Ctlg.Core;
+using Ctlg.Service.Commands;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ctlg.UnitTests
+{
+    public class FileEnumerateTests: BaseTestFixture
+    {
+        [TestCase(null, "*")]
+        [TestCase("foo", "foo")]
+        public void ReadTree_CreatesTree(string searchPatternParam, string searchPatternActuallyUsed)
+        {
+            using (var mock = AutoMock.GetLoose())
+            {
+                var file1 = new File("file1");
+                var file2 = new File("file2");
+                var nestedDir = new File("nested", true);
+                var rootDir = new File("root", true);
+
+                var nestedDirMock = new Mock<IFilesystemDirectory>();
+                nestedDirMock.SetupGet(d => d.Directory).Returns(nestedDir);
+                nestedDirMock.Setup(d => d.EnumerateFiles(It.Is<string>(searchPattern => searchPattern == searchPatternActuallyUsed)))
+                    .Returns(new[] { file1, file2 });
+                var rootDirMock = new Mock<IFilesystemDirectory>();
+                rootDirMock.SetupGet(d => d.Directory).Returns(rootDir);
+                rootDirMock.Setup(d => d.EnumerateDirectories()).Returns(new[] { nestedDirMock.Object });
+
+
+                mock.Mock<IFilesystemService>()
+                    .Setup(s => s.GetDirectory(It.Is<string>(path => path == "my-path")))
+                    .Returns(rootDirMock.Object);
+
+                var treeProvider = mock.Create<FileEnumerateStep>();
+
+                var tree = treeProvider.ReadTree("my-path", searchPatternParam);
+
+                rootDirMock.VerifyAll();
+                nestedDirMock.VerifyAll();
+
+                Assert.That(tree, Is.EqualTo(rootDir));
+                Assert.That(tree.Contents, Is.EqualTo(new[] { nestedDir }));
+                Assert.That(tree.Contents[0].Contents, Is.EqualTo(new[] { file1, file2 }));
+            }
+        }
+    }
+}

--- a/Ctlg.UnitTests/app.config
+++ b/Ctlg.UnitTests/app.config
@@ -8,7 +8,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.11.0.0" newVersion="4.11.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.12.0.0" newVersion="4.12.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />

--- a/Ctlg.UnitTests/packages.config
+++ b/Ctlg.UnitTests/packages.config
@@ -4,12 +4,12 @@
   <package id="Autofac.Extras.Moq" version="4.3.0" targetFramework="net452" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
-  <package id="Moq" version="4.11.0" targetFramework="net452" />
+  <package id="Moq" version="4.12.0" targetFramework="net452" />
   <package id="NUnit" version="3.12.0" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net452" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net452" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>

--- a/Ctlg/CommandLineOptions/Backup.cs
+++ b/Ctlg/CommandLineOptions/Backup.cs
@@ -9,6 +9,9 @@ namespace Ctlg.CommandLineOptions
         [Value(0)]
         public string Path { get; set; }
 
+        [Option('s', "search", HelpText = "Search pattern. Can contain wildcards * and ?.")]
+        public string SearchPattern { get; set; }
+
         [Option('n', "name", HelpText = "Backup name.")]
         public string Name { get; set; }
 

--- a/Ctlg/Program.cs
+++ b/Ctlg/Program.cs
@@ -77,6 +77,7 @@ namespace Ctlg
         {
             var command = Scope.Resolve<BackupCommand>();
             command.Path = options.Path;
+            command.SearchPattern = options.SearchPattern;
             command.SnapshotName = options.Name;
             command.IsFastMode = options.Fast;
 

--- a/tests/simple.bats
+++ b/tests/simple.bats
@@ -57,3 +57,14 @@ teardown() {
   echo -n "world" > "$CTLG_FILESDIR/world.txt"
   diff -r "$CTLG_FILESDIR" "${CTLG_RESTOREDIR}"
 }
+
+@test "backup filters files by search pattern" {
+  echo -n "hello" > "$CTLG_FILESDIR/hi.txt"
+  echo -n "test" > "$CTLG_FILESDIR/hi.bin"
+
+  $CTLG_EXECUTABLE backup -n Test1 -s *.txt ${CTLG_FILESDIR}
+
+  snapshot="snapshots/Test1/$(ls snapshots/Test1 | tail -1)"
+  file_list=$(cat "$snapshot" | awk '{ print $4 }')
+  [ "$file_list" == "hi.txt" ]
+}


### PR DESCRIPTION
## Summary

* Updated backup command: added support for `-s` parameter that filters files by name. 