### PR TITLE
Update Target Framework version. Use SHA-256 by default.

### DIFF
--- a/Ctlg.Core/Ctlg.Core.csproj
+++ b/Ctlg.Core/Ctlg.Core.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg.Core</RootNamespace>
     <AssemblyName>Ctlg.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>7.3</LangVersion>
+    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Ctlg.Data/App.config
+++ b/Ctlg.Data/App.config
@@ -19,6 +19,8 @@
     <DbProviderFactories>
       <remove invariant="System.Data.SQLite.EF6" />
       <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
-    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
+      <remove invariant="System.Data.SQLite" />
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
+    </DbProviderFactories>
   </system.data>
 </configuration>

--- a/Ctlg.Data/Ctlg.Data.csproj
+++ b/Ctlg.Data/Ctlg.Data.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg.Data</RootNamespace>
     <AssemblyName>Ctlg.Data</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -50,13 +50,13 @@
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.111.0\lib\net451\System.Data.SQLite.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.111.0\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite.EF6">
-      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.111.0\lib\net451\System.Data.SQLite.EF6.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.111.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite.Linq">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.111.0\lib\net451\System.Data.SQLite.Linq.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.111.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -80,5 +80,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/Ctlg.Data/packages.config
+++ b/Ctlg.Data/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
   <package id="System.Data.SQLite" version="1.0.111.0" targetFramework="net452" />
-  <package id="System.Data.SQLite.Core" version="1.0.111.0" targetFramework="net452" />
-  <package id="System.Data.SQLite.EF6" version="1.0.111.0" targetFramework="net452" />
-  <package id="System.Data.SQLite.Linq" version="1.0.111.0" targetFramework="net452" />
+  <package id="System.Data.SQLite.Core" version="1.0.111.0" targetFramework="net462" />
+  <package id="System.Data.SQLite.EF6" version="1.0.111.0" targetFramework="net462" />
+  <package id="System.Data.SQLite.Linq" version="1.0.111.0" targetFramework="net462" />
 </packages>

--- a/Ctlg.Db.Migrations/Ctlg.Db.Migrations.csproj
+++ b/Ctlg.Db.Migrations/Ctlg.Db.Migrations.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg.Db.Migrations</RootNamespace>
     <AssemblyName>Ctlg.Db.Migrations</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Ctlg.Filesystem/Ctlg.Filesystem.csproj
+++ b/Ctlg.Filesystem/Ctlg.Filesystem.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg.Filesystem</RootNamespace>
     <AssemblyName>Ctlg.Filesystem</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Ctlg.Service/Commands/AddCommand.cs
+++ b/Ctlg.Service/Commands/AddCommand.cs
@@ -15,35 +15,28 @@ namespace Ctlg.Service.Commands
         private IHashFunction HashFunction;
 
         private ITreeProvider TreeProvider { get; }
-        private IIndex<string, IHashFunction> HashFunctions { get; }
+        private ICtlgService CtlgService { get; }
         private IDataService DataService { get; }
         private IFilesystemService FilesystemService { get; }
         private IArchiveService ArchiveService { get; }
 
-        public AddCommand(ITreeProvider treeProvider, IIndex<string, IHashFunction> hashFunctions,
+        public AddCommand(ITreeProvider treeProvider, ICtlgService ctlgService,
             IDataService dataService, IFilesystemService filesystemService, IArchiveService archiveService)
         {
             DataService = dataService;
             FilesystemService = filesystemService;
             ArchiveService = archiveService;
             TreeProvider = treeProvider;
-            HashFunctions = hashFunctions;
+            CtlgService = ctlgService;
         }
 
-        public void Execute(ICtlgService svc)
+        public void Execute()
         {
-            var hashFunctionName = HashFunctionName ?? "SHA-1";
-            hashFunctionName = hashFunctionName.ToUpperInvariant();
-
-            if (!HashFunctions.TryGetValue(hashFunctionName, out HashFunction))
-            {
-                throw new Exception($"Unsupported hash function {hashFunctionName}");
-            }
+            HashFunction = CtlgService.GetHashFunction(HashFunctionName ?? "SHA-256");
 
             var root = TreeProvider.ReadTree(Path, SearchPattern);
             var treeWalker = new TreeWalker(root);
             treeWalker.Walk(ProcessFile);
-
 
             DataService.AddDirectory(root);
 

--- a/Ctlg.Service/Commands/BackupCommand.cs
+++ b/Ctlg.Service/Commands/BackupCommand.cs
@@ -6,7 +6,7 @@ namespace Ctlg.Service.Commands
 {
     public class BackupCommand: ICommand
     {
-        public string SnapshotName { get; set; }
+        public string Name { get; set; }
         public string Path { get; set; }
         public string SearchPattern { get; set; }
         public bool IsFastMode { get; set; }
@@ -24,12 +24,12 @@ namespace Ctlg.Service.Commands
 
             if (IsFastMode)
             {
-                SnapshotReader.ReadHashesFromLatestSnapshot(SnapshotName, root);
+                SnapshotReader.ReadHashesFromLatestSnapshot(Name, root);
             }
 
             var treeWalker = new TreeWalker(root);
 
-            using (var snapshot = SnapshotService.CreateSnapshotWriter(SnapshotName))
+            using (var snapshot = SnapshotService.CreateSnapshotWriter(Name))
             {
                 treeWalker.Walk(snapshot.AddFile);
             }

--- a/Ctlg.Service/Commands/BackupCommand.cs
+++ b/Ctlg.Service/Commands/BackupCommand.cs
@@ -18,7 +18,7 @@ namespace Ctlg.Service.Commands
             SnapshotReader = snapshotReader;
         }
 
-        public void Execute(ICtlgService ctlgService)
+        public void Execute()
         {
             var root = TreeProvider.ReadTree(Path, SearchPattern);
 

--- a/Ctlg.Service/Commands/FindCommand.cs
+++ b/Ctlg.Service/Commands/FindCommand.cs
@@ -10,18 +10,25 @@ namespace Ctlg.Service.Commands
         public long? Size { get; set; }
         public string NamePattern { get; set; }
 
-        public void Execute(ICtlgService ctlgService)
+        public FindCommand(ICtlgService ctlgService)
+        {
+            CtlgService = ctlgService;
+        }
+
+        public void Execute()
         {
             Hash hash = null;
             if (HashFunctionName != null && Hash != null)
             {
-                var hashAlgorithm = ctlgService.GetHashAlgorithm(HashFunctionName.ToUpperInvariant());
+                var hashAlgorithm = CtlgService.GetHashAlgorithm(HashFunctionName.ToUpperInvariant());
                 var bytes = FormatBytes.ToByteArray(Hash);
 
                 hash = new Hash(hashAlgorithm.HashAlgorithmId, bytes);
             }
 
-            ctlgService.FindFiles(hash, Size, NamePattern);
+            CtlgService.FindFiles(hash, Size, NamePattern);
         }
+
+        private ICtlgService CtlgService { get; }
     }
 }

--- a/Ctlg.Service/Commands/FindCommand.cs
+++ b/Ctlg.Service/Commands/FindCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Ctlg.Core;
+using Ctlg.Service.Events;
 using Ctlg.Service.Utils;
 
 namespace Ctlg.Service.Commands
@@ -17,6 +18,20 @@ namespace Ctlg.Service.Commands
 
         public void Execute()
         {
+            if (Hash != null && HashFunctionName == null)
+            {
+                DomainEvents.Raise(new ErrorEvent("Checksum value parameter requires Hash function to be provided."));
+                return;
+            }
+
+            if (Hash == null &&
+                Size == null &&
+                NamePattern == null)
+            {
+                DomainEvents.Raise(new ErrorEvent("No parameters provided."));
+                return;
+            }
+
             Hash hash = null;
             if (HashFunctionName != null && Hash != null)
             {

--- a/Ctlg.Service/Commands/ICommand.cs
+++ b/Ctlg.Service/Commands/ICommand.cs
@@ -2,6 +2,6 @@
 {
     public interface ICommand
     {
-        void Execute(ICtlgService ctlgService);
+        void Execute();
     }
 }

--- a/Ctlg.Service/Commands/ListCommand.cs
+++ b/Ctlg.Service/Commands/ListCommand.cs
@@ -2,9 +2,16 @@
 {
     public class ListCommand: ICommand
     {
-        public void Execute(ICtlgService ctlgService)
+        public ListCommand(ICtlgService ctlgService)
         {
-            ctlgService.ListFiles();
+            CtlgService = ctlgService;
         }
+
+        public void Execute()
+        {
+            CtlgService.ListFiles();
+        }
+
+        private ICtlgService CtlgService { get; }
     }
 }

--- a/Ctlg.Service/Commands/RestoreCommand.cs
+++ b/Ctlg.Service/Commands/RestoreCommand.cs
@@ -24,7 +24,7 @@ namespace Ctlg.Service.Commands
             FileSystemService = fileSystemService;
         }
 
-        public void Execute(ICtlgService ctlgService)
+        public void Execute()
         {
             var snapshotPath = SnapshotService.FindSnapshotPath(Name, Date);
             var snapshotRecords = SnapshotService.ReadSnapshotFile(snapshotPath);

--- a/Ctlg.Service/Commands/ShowCommand.cs
+++ b/Ctlg.Service/Commands/ShowCommand.cs
@@ -5,19 +5,20 @@ namespace Ctlg.Service.Commands
 {
     public class ShowCommand : ICommand
     {
-        public ShowCommand(IList<int> catalogEntryIds)
+        public ShowCommand(ICtlgService ctlgService)
         {
-            CatalogEntryIds = catalogEntryIds;
+            CtlgService = ctlgService;
         }
 
-        public void Execute(ICtlgService ctlgService)
+        public void Execute()
         {
             foreach (var id in CatalogEntryIds)
             {
-                ctlgService.Show(id);
+                CtlgService.Show(id);
             }
         }
 
-        public IList<int> CatalogEntryIds { get; }
+        public IList<int> CatalogEntryIds { get; set; }
+        private ICtlgService CtlgService { get; }
     }
 }

--- a/Ctlg.Service/Ctlg.Service.csproj
+++ b/Ctlg.Service/Ctlg.Service.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg.Service</RootNamespace>
     <AssemblyName>Ctlg.Service</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Ctlg.Service/CtlgService.cs
+++ b/Ctlg.Service/CtlgService.cs
@@ -71,6 +71,17 @@ namespace Ctlg.Service
             return algorithm;
         }
 
+        public IHashFunction GetHashFunction(string name)
+        {
+            var canonicName = name.ToUpperInvariant();
+            if (!HashFunctions.TryGetValue(name, out IHashFunction hashFunction))
+            {
+                throw new Exception($"Unsupported hash function {name}");
+            }
+
+            return hashFunction;
+        }
+
         private void OutputFiles(IEnumerable<File> files, int level = 0)
         {
             foreach (var file in files)
@@ -78,18 +89,6 @@ namespace Ctlg.Service
                 DomainEvents.Raise(new TreeItemEnumerated(file, level));
 
                 OutputFiles(file.Contents, level + 1);
-            }
-        }
-
-        public void Execute(ICommand command)
-        {
-            try
-            {
-                command.Execute(this);
-            }
-            catch (Exception e)
-            {
-                DomainEvents.Raise(new ErrorEvent(e));
             }
         }
 

--- a/Ctlg.Service/DomainEvents.cs
+++ b/Ctlg.Service/DomainEvents.cs
@@ -10,7 +10,7 @@ namespace Ctlg.Service
     /// </summary>
     public static class DomainEvents
     {
-        public static ILifetimeScope Container { get; set; }
+        public static IComponentContext Context { private get; set; }
 
         [ThreadStatic]
         private static List<Delegate> _actions;
@@ -31,9 +31,9 @@ namespace Ctlg.Service
 
         public static void Raise<T>(T args) where T : IDomainEvent
         {
-            if (Container != null)
+            if (Context != null)
             {
-                foreach (var handler in Container.Resolve<IEnumerable<IHandle<T>>>())
+                foreach (var handler in Context.Resolve<IEnumerable<IHandle<T>>>())
                 {
                     handler.Handle(args);
                 }

--- a/Ctlg.Service/ICtlgService.cs
+++ b/Ctlg.Service/ICtlgService.cs
@@ -1,11 +1,11 @@
 ﻿using Ctlg.Core;
+using Ctlg.Core.Interfaces;
 using Ctlg.Service.Commands;
 
 namespace Ctlg.Service
 {
     public interface ICtlgService
     {
-        void Execute(ICommand command);
         void ApplyDbMigrations();
 
         void ListFiles();
@@ -13,6 +13,8 @@ namespace Ctlg.Service
         void Show(int catalgoEntryId);
 
         HashAlgorithm GetHashAlgorithm(string hashAlgorithmName);
+
+        IHashFunction GetHashFunction(string name);
 
         string GetBackupFilePath(string hash);
         void SortTree(File directory);

--- a/Ctlg.Service/SnapshotService.cs
+++ b/Ctlg.Service/SnapshotService.cs
@@ -13,11 +13,10 @@ namespace Ctlg.Service
 {
     public class SnapshotService: ISnapshotService
     {
-        public SnapshotService(IFilesystemService filesystemService, ICtlgService ctlgService, IIndex<string, IHashFunction> hashFunctions)
+        public SnapshotService(IFilesystemService filesystemService, ICtlgService ctlgService)
         {
             FilesystemService = filesystemService;
             CtlgService = ctlgService;
-            HashFunctions = hashFunctions;
 
             var currentDirectory = FilesystemService.GetCurrentDirectory();
             SnapshotsDirectory = FilesystemService.CombinePath(currentDirectory, "snapshots");
@@ -79,11 +78,7 @@ namespace Ctlg.Service
 
         public ISnapshotWriter CreateSnapshotWriter(string name)
         {
-            var hashFunctionName = "SHA-256";
-            if (!HashFunctions.TryGetValue(hashFunctionName, out IHashFunction hashFunction))
-            {
-                throw new Exception($"Unsupported hash function {hashFunctionName}");
-            }
+            var hashFunction = CtlgService.GetHashFunction("SHA-256");
 
             var backupDirectory = GetSnapshotDirectory(name);
             FilesystemService.CreateDirectory(backupDirectory);

--- a/Ctlg.UnitTests/BackupCommandTests.cs
+++ b/Ctlg.UnitTests/BackupCommandTests.cs
@@ -23,7 +23,7 @@ namespace Ctlg.UnitTests
                 command.Path = "test-path";
                 command.SnapshotName = "test-name";
 
-                command.Execute(null);
+                command.Execute();
 
                 writerMock.VerifyAll();
             }
@@ -46,7 +46,7 @@ namespace Ctlg.UnitTests
                 command.SnapshotName = "test-name";
                 command.IsFastMode = true;
 
-                command.Execute(null);
+                command.Execute();
 
                 snapshotReaderMock.VerifyAll();
             }

--- a/Ctlg.UnitTests/BackupCommandTests.cs
+++ b/Ctlg.UnitTests/BackupCommandTests.cs
@@ -21,7 +21,7 @@ namespace Ctlg.UnitTests
 
                 var command = mock.Create<BackupCommand>();
                 command.Path = "test-path";
-                command.SnapshotName = "test-name";
+                command.Name = "test-name";
 
                 command.Execute();
 
@@ -43,7 +43,7 @@ namespace Ctlg.UnitTests
 
                 var command = mock.Create<BackupCommand>();
                 command.Path = "test-path";
-                command.SnapshotName = "test-name";
+                command.Name = "test-name";
                 command.IsFastMode = true;
 
                 command.Execute();

--- a/Ctlg.UnitTests/Ctlg.UnitTests.csproj
+++ b/Ctlg.UnitTests/Ctlg.UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg.UnitTests</RootNamespace>
     <AssemblyName>Ctlg.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -49,43 +49,46 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="mscorlib" />
+    <Reference Include="Autofac">
+      <HintPath>..\packages\Autofac.4.9.2\lib\net45\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.NonGeneric">
+      <HintPath>..\packages\System.Collections.NonGeneric.4.3.0\lib\net46\System.Collections.NonGeneric.dll</HintPath>
+    </Reference>
+    <Reference Include="Autofac.Extras.Moq">
+      <HintPath>..\packages\Autofac.Extras.Moq.4.3.0\lib\net45\Autofac.Extras.Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core">
       <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Configuration" />
     <Reference Include="EntityFramework">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="mscorlib" />
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.12.0\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Extras.Moq">
-      <HintPath>..\packages\Autofac.Extras.Moq.4.3.0\lib\net45\Autofac.Extras.Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Autofac">
-      <HintPath>..\packages\Autofac.4.9.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Primitives">
       <HintPath>..\packages\System.ComponentModel.Primitives.4.3.0\lib\net45\System.ComponentModel.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.TypeConverter">
-      <HintPath>..\packages\System.ComponentModel.TypeConverter.4.3.0\lib\net45\System.ComponentModel.TypeConverter.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.ComponentModel.TypeConverter.4.3.0\lib\net462\System.ComponentModel.TypeConverter.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.3\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/Ctlg.UnitTests/FindCommandTests.cs
+++ b/Ctlg.UnitTests/FindCommandTests.cs
@@ -14,11 +14,6 @@ namespace Ctlg.UnitTests
         [Test]
         public void Execute_Always_CallsFindFiles()
         {
-            var command = new FindCommand
-            {
-                HashFunctionName = "test",
-                Hash = "01FF"
-            };
 
             var serviceMock = new Mock<ICtlgService>(MockBehavior.Strict);
 
@@ -31,7 +26,12 @@ namespace Ctlg.UnitTests
                 It.IsAny<long?>(),
                 It.IsAny<string>())).Callback<Hash, long?, string>((h, s, n) => hashParameter = h.Value);
 
-            command.Execute(serviceMock.Object);
+            var command = new FindCommand(serviceMock.Object)
+            {
+                HashFunctionName = "test",
+                Hash = "01FF"
+            };
+            command.Execute();
 
             serviceMock.VerifyAll();
             Assert.That(FormatBytes.ToHexString(hashParameter), Is.EqualTo("01ff").IgnoreCase);

--- a/Ctlg.UnitTests/ListCommandTests.cs
+++ b/Ctlg.UnitTests/ListCommandTests.cs
@@ -11,12 +11,13 @@ namespace Ctlg.UnitTests
         [Test]
         public void Execute_WhenCalled_CallsListFiles()
         {
-            var command = new ListCommand();
 
             var serviceMock = new Mock<ICtlgService>(MockBehavior.Strict);
             serviceMock.Setup(s => s.ListFiles());
 
-            command.Execute(serviceMock.Object);
+            var command = new ListCommand(serviceMock.Object);
+
+            command.Execute();
 
             serviceMock.VerifyAll();
         }

--- a/Ctlg.UnitTests/RestoreCommandTests.cs
+++ b/Ctlg.UnitTests/RestoreCommandTests.cs
@@ -60,7 +60,7 @@ namespace Ctlg.UnitTests
             command.Name = BackupName;
             command.Path = @"C:\foo";
 
-            command.Execute(null);
+            command.Execute();
         }
     }
 }

--- a/Ctlg.UnitTests/app.config
+++ b/Ctlg.UnitTests/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Ctlg.UnitTests/packages.config
+++ b/Ctlg.UnitTests/packages.config
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.9.2" targetFramework="net452" />
-  <package id="Autofac.Extras.Moq" version="4.3.0" targetFramework="net452" />
-  <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
-  <package id="Moq" version="4.12.0" targetFramework="net452" />
-  <package id="NUnit" version="3.12.0" targetFramework="net452" />
-  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net452" />
-  <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net452" />
-  <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net452" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net452" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net452" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
+  <package id="Autofac" version="4.9.2" targetFramework="net462" />
+  <package id="Autofac.Extras.Moq" version="4.3.0" targetFramework="net462" />
+  <package id="Castle.Core" version="4.4.0" targetFramework="net462" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
+  <package id="Moq" version="4.12.0" targetFramework="net462" />
+  <package id="NUnit" version="3.12.0" targetFramework="net462" />
+  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net462" />
+  <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net462" />
+  <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
 </packages>

--- a/Ctlg/App.config
+++ b/Ctlg/App.config
@@ -20,8 +20,8 @@
     <DbProviderFactories>
       <remove invariant="System.Data.SQLite.EF6" />
       <remove invariant="System.Data.SQLite" />
-      <add invariant="System.Data.SQLite.EF6" name="SQLite Data Provider (Entity Framework 6)" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
-      <add invariant="System.Data.SQLite" name="SQLite Data Provider" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
     </DbProviderFactories>
   </system.data>
 </configuration>

--- a/Ctlg/CommandLineOptions/Add.cs
+++ b/Ctlg/CommandLineOptions/Add.cs
@@ -7,7 +7,7 @@ namespace Ctlg.CommandLineOptions
     class Add
     {
         [Value(0, MetaName = "Path")]
-        public IList<string> Path { get; set; }
+        public string Path { get; set; }
 
         [Option('s', "search", HelpText = "Search pattern. Can contain wildcards * and ?.")]
         public string SearchPattern { get; set; }

--- a/Ctlg/CommandLineOptions/Backup.cs
+++ b/Ctlg/CommandLineOptions/Backup.cs
@@ -16,6 +16,6 @@ namespace Ctlg.CommandLineOptions
         public string Name { get; set; }
 
         [Option('f', "fast", HelpText = "Fast mode.", Default = false)]
-        public bool Fast { get; set; }
+        public bool IsFastMode { get; set; }
     }
 }

--- a/Ctlg/CommandLineOptions/Find.cs
+++ b/Ctlg/CommandLineOptions/Find.cs
@@ -9,7 +9,7 @@ namespace Ctlg.CommandLineOptions
         public string HashFunctionName { get; set; }
 
         [Option('c', "checksum", HelpText = "Checksum value.")]
-        public string Checksum { get; set; }
+        public string Hash { get; set; }
 
         [Option('s', "size", HelpText = "File size in bytes.")]
         public long? Size { get; set; }

--- a/Ctlg/Ctlg.csproj
+++ b/Ctlg/Ctlg.csproj
@@ -9,14 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ctlg</RootNamespace>
     <AssemblyName>Ctlg</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -50,6 +49,12 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="Autofac">
+      <HintPath>..\packages\Autofac.4.9.2\lib\net45\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="CommandLine">
+      <HintPath>..\packages\CommandLineParser.2.5.0\lib\net461\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="Crc32.NET">
       <HintPath>..\packages\Crc32.NET.1.2.0\lib\net20\Crc32.NET.dll</HintPath>
     </Reference>
@@ -60,19 +65,16 @@
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.111.0\lib\net451\System.Data.SQLite.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.111.0\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite.EF6">
-      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.111.0\lib\net451\System.Data.SQLite.EF6.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.111.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.SQLite.Linq">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.111.0\lib\net451\System.Data.SQLite.Linq.dll</HintPath>
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.111.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac">
-      <HintPath>..\packages\Autofac.4.9.2\lib\net45\Autofac.dll</HintPath>
-    </Reference>
-    <Reference Include="CommandLine">
-      <HintPath>..\packages\CommandLineParser.2.5.0\lib\net45\CommandLine.dll</HintPath>
+    <Reference Include="AutoMapper">
+      <HintPath>..\packages\AutoMapper.8.1.1\lib\net461\AutoMapper.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -117,5 +119,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/Ctlg/IProgram.cs
+++ b/Ctlg/IProgram.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using Autofac;
 
 namespace Ctlg
 {
-  public interface IProgram
+    public interface IProgram
     {
-    int Run(ILifetimeScope scope, string[] args);
+        int Run(string[] args);
     }
 }

--- a/Ctlg/Program.cs
+++ b/Ctlg/Program.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Security.Cryptography;
 using Autofac;
+using AutoMapper;
 using CommandLine;
 using Ctlg.CommandLineOptions;
 using Ctlg.Core;
@@ -21,7 +22,7 @@ namespace Ctlg
     class Program: IProgram, IHandle<ErrorEvent>
     {
         private ICtlgService CtlgService { get; set; }
-        private ILifetimeScope Scope { get; set; }
+        private IMapper Mapper { get; }
         private int ExitCode { get; set; }
 
         static int Main(string[] args)
@@ -29,130 +30,61 @@ namespace Ctlg
             var container = BuildIocContainer();
             using (var scope = container.BeginLifetimeScope())
             {
-                DomainEvents.Container = scope;
+                DomainEvents.Context = scope.Resolve<IComponentContext>();
 
                 var program = scope.Resolve<IProgram>();
-                return program.Run(scope, args);
+                return program.Run(args);
             }
         }
 
-        public Program(ICtlgService ctlgService)
+        public Program(ICtlgService ctlgService, IMapper mapper)
         {
             CtlgService = ctlgService;
+            Mapper = mapper;
         }
 
-        public int Run(ILifetimeScope scope, string[] args)
+        public int Run(string[] args)
         {
             ExitCode = 0;
-
-            Scope = scope;
 
             CtlgService.ApplyDbMigrations();
 
             Parser.Default.ParseArguments<Add, Backup, Find, List, Restore, Show>(args)
-                .WithParsed<Add>(opts => RunAdd(opts))
-                .WithParsed<Backup>(opts => RunBackupCommand(opts))
-                .WithParsed<Find>(opts => RunFindCommand(opts))
-                .WithParsed<List>(opts => RunListCommand(opts))
-                .WithParsed<Restore>(opts => RunRestoreCommand(opts))
-                .WithParsed<Show>(opts => RunShowCommand(opts))
+                .WithParsed<Add>(opts => Run<AddCommand>(opts))
+                .WithParsed<Backup>(opts => Run<BackupCommand>(opts))
+                .WithParsed<Find>(opts => Run<FindCommand>(opts))
+                .WithParsed<List>(opts => Run<ListCommand>(opts))
+                .WithParsed<Restore>(opts => Run<RestoreCommand>(opts))
+                .WithParsed<Show>(opts => Run<ShowCommand>(opts))
                 .WithNotParsed(errors => { ExitCode = 1; });
 
             return ExitCode;
         }
 
-        private void SetupAndExecute<T>(Action<T> setupActon) where T : ICommand
+        private void Run<T>(object options) where T : ICommand
         {
-            var command = Scope.Resolve<T>();
-
-            setupActon(command);
+            var command = Mapper.Map<T>(options);
 
             command.Execute();
-        }
-
-        private void RunAdd(Add options)
-        {
-            SetupAndExecute<AddCommand>(command => {
-                command.Path = options.Path.First();
-                command.SearchPattern = options.SearchPattern;
-                command.HashFunctionName = options.HashFunctionName;
-            });
-        }
-
-        private void RunBackupCommand(Backup options)
-        {
-            SetupAndExecute<BackupCommand>(command => {
-                command.Path = options.Path;
-                command.SearchPattern = options.SearchPattern;
-                command.SnapshotName = options.Name;
-                command.IsFastMode = options.Fast;
-            });
-        }
-
-        private void RunFindCommand(Find options)
-        {
-            if (options.Checksum != null && options.HashFunctionName == null)
-            {
-                DomainEvents.Raise(new ErrorEvent("Checksum value parameter requires Hash function to be provided."));
-                return;
-            }
-
-            if (options.Checksum == null &&
-                options.Size == null &&
-                options.NamePattern == null)
-            {
-                DomainEvents.Raise(new ErrorEvent("No parameters provided."));
-                return;
-            }
-
-            SetupAndExecute<FindCommand>(command => {
-                command.Hash = options.Checksum;
-                command.HashFunctionName = options.HashFunctionName;
-                command.NamePattern = options.NamePattern;
-                command.Size = options.Size;
-            });
-        }
-
-        private void RunListCommand(List options)
-        {
-            SetupAndExecute<ListCommand>(command => {});
-        }
-
-        private void RunRestoreCommand(Restore options)
-        {
-            SetupAndExecute<RestoreCommand>(command => {
-                command.Path = options.Path;
-                command.Name = options.Name;
-                command.Date = options.Date;
-            });
-        }
-
-        private void RunShowCommand(Show options)
-        {
-            var ids = options.CatalogEntryIds.Select(int.Parse).ToList();
-
-            SetupAndExecute<ShowCommand>(command => {
-                command.CatalogEntryIds = ids;
-            });
         }
 
         private static IContainer BuildIocContainer()
         {
             var builder = new ContainerBuilder();
 
-            builder.RegisterType<DataService>().As<IDataService>();
-            builder.RegisterType<MigrationService>().As<IMigrationService>();
+            builder.RegisterType<DataService>().As<IDataService>().InstancePerLifetimeScope();
+            builder.RegisterType<MigrationService>().As<IMigrationService>().InstancePerLifetimeScope();
 
             if (IsMonoRuntime())
             {
-                builder.RegisterType<FilesystemService>().As<IFilesystemService>();
+                builder.RegisterType<FilesystemService>().As<IFilesystemService>().InstancePerLifetimeScope();
             }
             else
             {
-                builder.RegisterType<FilesystemServiceLongPath>().As<IFilesystemService>();
+                builder.RegisterType<FilesystemServiceLongPath>().As<IFilesystemService>().InstancePerLifetimeScope();
             }
-            builder.RegisterType<ArchiveService>().As<IArchiveService>();
-            builder.RegisterType<SnapshotService>().As<ISnapshotService>();
+            builder.RegisterType<ArchiveService>().As<IArchiveService>().InstancePerLifetimeScope();
+            builder.RegisterType<SnapshotService>().As<ISnapshotService>().InstancePerLifetimeScope();
             builder.RegisterCryptographyHashFunction<MD5Cng>("MD5", HashAlgorithmId.MD5);
             builder.RegisterCryptographyHashFunction<SHA1Cng>("SHA-1", HashAlgorithmId.SHA1);
             builder.RegisterCryptographyHashFunction<SHA256Cng>("SHA-256", HashAlgorithmId.SHA256);
@@ -160,8 +92,8 @@ namespace Ctlg
             builder.RegisterCryptographyHashFunction<SHA512Cng>("SHA-512", HashAlgorithmId.SHA512);
             builder.RegisterCryptographyHashFunction<Crc32Algorithm>("CRC32", HashAlgorithmId.CRC32);
 
-            builder.RegisterType<CtlgContext>().As<ICtlgContext>();
-            builder.RegisterType<CtlgService>().As<ICtlgService>();
+            builder.RegisterType<CtlgContext>().As<ICtlgContext>().InstancePerLifetimeScope();
+            builder.RegisterType<CtlgService>().As<ICtlgService>().InstancePerLifetimeScope();
 
             var genericHandlerType = typeof(IHandle<>);
             builder.RegisterAssemblyTypes(typeof(Program).Assembly)
@@ -172,13 +104,35 @@ namespace Ctlg
             builder.RegisterAssemblyTypes(typeof(AddCommand).Assembly)
                 .Where(t => t.IsAssignableTo<ICommand>())
                 .AsSelf()
-                .InstancePerLifetimeScope();
+                .InstancePerDependency();
 
-            builder.RegisterType<FileEnumerateStep>().As<ITreeProvider>();
-            builder.RegisterType<SnapshotReader>().As<ISnapshotReader>();
+            builder.RegisterType<FileEnumerateStep>().As<ITreeProvider>().InstancePerLifetimeScope();
+            builder.RegisterType<SnapshotReader>().As<ISnapshotReader>().InstancePerLifetimeScope();
+            builder.Register(context => CreateMappingConfiguration())
+                .As<IConfigurationProvider>().InstancePerLifetimeScope();
 
+            builder.Register(context =>
+            {
+                var scope = context.Resolve<IComponentContext>();
+                var configuration = context.Resolve<IConfigurationProvider>();
+
+                return new Mapper(configuration, scope.Resolve);
+            }).As<IMapper>().InstancePerLifetimeScope();
 
             return builder.Build();
+        }
+
+        private static IConfigurationProvider CreateMappingConfiguration()
+        {
+            return new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Add, AddCommand>().ConstructUsingServiceLocator();
+                cfg.CreateMap<Backup, BackupCommand>().ConstructUsingServiceLocator();
+                cfg.CreateMap<Find, FindCommand>().ConstructUsingServiceLocator();
+                cfg.CreateMap<List, ListCommand>().ConstructUsingServiceLocator();
+                cfg.CreateMap<Restore, RestoreCommand>().ConstructUsingServiceLocator();
+                cfg.CreateMap<Show, ShowCommand>().ConstructUsingServiceLocator();
+            });
         }
 
         private static bool IsMonoRuntime()

--- a/Ctlg/packages.config
+++ b/Ctlg/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.9.2" targetFramework="net452" />
-  <package id="CommandLineParser" version="2.5.0" targetFramework="net452" />
-  <package id="Crc32.NET" version="1.2.0" targetFramework="net452" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
-  <package id="System.Data.SQLite" version="1.0.111.0" targetFramework="net452" />
-  <package id="System.Data.SQLite.Core" version="1.0.111.0" targetFramework="net452" />
-  <package id="System.Data.SQLite.EF6" version="1.0.111.0" targetFramework="net452" />
-  <package id="System.Data.SQLite.Linq" version="1.0.111.0" targetFramework="net452" />
+  <package id="Autofac" version="4.9.2" targetFramework="net462" />
+  <package id="AutoMapper" version="8.1.1" targetFramework="net462" />
+  <package id="CommandLineParser" version="2.5.0" targetFramework="net462" />
+  <package id="Crc32.NET" version="1.2.0" targetFramework="net462" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
+  <package id="System.Data.SQLite" version="1.0.111.0" targetFramework="net462" />
+  <package id="System.Data.SQLite.Core" version="1.0.111.0" targetFramework="net462" />
+  <package id="System.Data.SQLite.EF6" version="1.0.111.0" targetFramework="net462" />
+  <package id="System.Data.SQLite.Linq" version="1.0.111.0" targetFramework="net462" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -12,56 +12,111 @@ A tool to catalog files and folders.
 
 ## Usage
 
-    ctlg <command> [<args>]
-
-    ctlg add -s <mask> -f <hash function> <directory>
-    ctlg show <catalog entry IDs>
-    ctlg find -f <hash function> -c <checksum> -s <size> -n <name pattern>
-    ctlg list
-    ctlg backup -f -n <backup name> -s <search pattern> <directory>
-    ctlg restore -n <backup name> -d <date> <directory>
+    ctlg <command> [<options>]
 
 ### Add
+
+    ctlg add -s <mask> -f <hash function> <directory>
 
 Scan directory and add files to the catalog.
 
 Available options:
 
-`-s <mask>`
-
-`--search <mask>`
+    -s <mask>
+    --search <mask>
 
 Include only files specified by `<mask>`. Can contain wildcards * and ?. Default is `*`.
 
-`-f <hash function>`
+    -f <hash function>
+    --function <hash function>
 
-`--function <hash function>`
-
-Apply `<hash function>` to files when adding them to the catalog. Default is `SHA-1`.
+Apply `<hash function>` to files when adding them to the catalog. Default is `SHA-256`.
 
 ### show
+
+    ctlg show <catalog entry IDs>
 
 Show detailed information about catalog enty.
 
 ### find
 
+    ctlg find -f <hash function> -c <checksum> -s <size> -n <mask>
+
 Find file in the catalog. It is possible to search files by name, size, and checksum value.
 
+Available options:
+
+    -f <hash function>
+    --function <hash function>
+
+Specifies the `<hash function>`.
+
+    -c <hash value>
+    --checksum <hash value>
+
+Specifies the `<hash value>`.
+
+    -s <size>
+    --size <size>
+
+Size in bytes.
+
+    -n <mask>
+    --name <mask>
+
+Include files by name matching <mask>.
+
 ### list
+
+    ctlg list
 
 List all files in the catalog.
 
 ### backup
 
+    ctlg backup -f -n <backup name> -s <mask> <directory>
+
 Backup files from specified directory.
+
+Available options:
+
+    -n <backup name>
+    --name <backup name>
+
+Backup name. Required.
+
+    -s <mask>
+    --search <mask>
+
+Include files by name matching <mask>.
+
+    -f
+    --fast
+
+Fast mode. Does not recalculate hashes if file was not modified since last backup.
 
 ### restore
 
+    ctlg restore -n <backup name> -d <date> <directory>
+
 Restore files from backup to specified directory.
+
+Available options:
+
+    -n <backup name>
+    --name <backup name>
+
+Backup name. Required.
+
+    -d <date>
+    --date <date>
+
+Date when backup was taken. When there is no exact match, finds most recent backup that was taken before the <date>.
+
 
 ## Implementation details
 
- - .NET console application.
+ - .NET console application (.NET Framework 4.6.2).
  - Entity Framework with SQLite DB, database migrations in SQL.
  - Pri.LongPath is used to support long paths.
  - Autofac is used to inject dpendencies.

--- a/tests/backup.bats
+++ b/tests/backup.bats
@@ -1,24 +1,6 @@
 #!/usr/bin/env bats
 
-setup() {
-  CTLG_TEMPDIR="$(mktemp -d "${BATS_TMPDIR}/ctlg_tests.XXX")"
-  CTLG_FILESDIR="${CTLG_TEMPDIR}/files"
-  CTLG_RESTOREDIR="${CTLG_TEMPDIR}/restore"
-  CTLG_WORKDIR="${CTLG_TEMPDIR}/work"
-  CTLG_EXECUTABLE="mono ${BATS_TEST_DIRNAME}/../Ctlg/bin/Debug/Ctlg.exe"
-
-
-  mkdir "${CTLG_FILESDIR}"
-  mkdir "${CTLG_WORKDIR}"
-  mkdir "${CTLG_RESTOREDIR}"
-  cd "${CTLG_WORKDIR}"
-
-  # echo "# Setup ${CTLG_TEMPDIR}" >&3
-}
-
-teardown() {
-  rm -rf "${CTLG_TEMPDIR}"
-}
+load helper
 
 @test "backup and restore one file" {
   echo -n "hello" > ${CTLG_FILESDIR}/hi.txt

--- a/tests/catalog.bats
+++ b/tests/catalog.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+load helper
+
+@test "add one file using default checksum method" {
+  echo -n "hello" > ${CTLG_FILESDIR}/hi.txt
+  $CTLG_EXECUTABLE add ${CTLG_FILESDIR}
+
+  output=$($CTLG_EXECUTABLE find -c 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 -f sha-256)
+
+  [[ "${output}" == *"hi.txt"* ]]
+}

--- a/tests/catalog.bats
+++ b/tests/catalog.bats
@@ -3,10 +3,40 @@
 load helper
 
 @test "add one file using default checksum method" {
-  echo -n "hello" > ${CTLG_FILESDIR}/hi.txt
-  $CTLG_EXECUTABLE add ${CTLG_FILESDIR}
+  echo -n "hello" > $CTLG_FILESDIR/hi.txt
+  $CTLG_EXECUTABLE add $CTLG_FILESDIR
 
   output=$($CTLG_EXECUTABLE find -c 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 -f sha-256)
-
   [[ "${output}" == *"hi.txt"* ]]
+
+  output=$($CTLG_EXECUTABLE list)
+  [[ "${output}" == *"hi.txt"* ]]
+
+  output=$($CTLG_EXECUTABLE show 2)
+  [[ "${output}" == *"hi.txt"* ]]
+}
+
+@test "when adding archive it parses content" {
+  echo -n "hello" > $CTLG_FILESDIR/hi.txt
+  zip -j $CTLG_FILESDIR/1.zip $CTLG_FILESDIR/hi.txt
+  rm $CTLG_FILESDIR/hi.txt
+  $CTLG_EXECUTABLE add $CTLG_FILESDIR
+
+  output=$($CTLG_EXECUTABLE find --name "hi.txt")
+  [[ "${output}" == *"hi.txt"* ]]
+
+  output=$($CTLG_EXECUTABLE find --checksum 3610a686 --function CRC32)
+  [[ "${output}" == *"hi.txt"* ]]
+
+  output=$($CTLG_EXECUTABLE find --size 5)
+  [[ "${output}" == *"hi.txt"* ]]
+}
+
+@test "add files filtering by name" {
+  echo -n "hello" > $CTLG_FILESDIR/hi.txt
+  echo -n "world" > $CTLG_FILESDIR/w.txt
+  echo -n "test" > $CTLG_FILESDIR/test
+
+  output=$($CTLG_EXECUTABLE add --search "*.txt" --function CRC32 $CTLG_FILESDIR)
+  [[ "${output}" == *"2 files found"* ]]
 }

--- a/tests/helper.bash
+++ b/tests/helper.bash
@@ -1,0 +1,19 @@
+setup() {
+  CTLG_TEMPDIR="$(mktemp -d "${BATS_TMPDIR}/ctlg_tests.XXX")"
+  CTLG_FILESDIR="${CTLG_TEMPDIR}/files"
+  CTLG_RESTOREDIR="${CTLG_TEMPDIR}/restore"
+  CTLG_WORKDIR="${CTLG_TEMPDIR}/work"
+  CTLG_EXECUTABLE="mono ${BATS_TEST_DIRNAME}/../Ctlg/bin/Debug/Ctlg.exe"
+
+
+  mkdir "${CTLG_FILESDIR}"
+  mkdir "${CTLG_WORKDIR}"
+  mkdir "${CTLG_RESTOREDIR}"
+  cd "${CTLG_WORKDIR}"
+
+  # echo "# Setup ${CTLG_TEMPDIR}" >&3
+}
+
+teardown() {
+  rm -rf "${CTLG_TEMPDIR}"
+}


### PR DESCRIPTION
## Summary

* Updated target framework version to `.NET Framework 4.6.2`.
* Updated `add` command to use `SHA-256` by default.
* Updated documentation.
* Added more integration tests for catalog commands.
