### PR TITLE
Update snapshot selection logic when date param is provided

### DIFF
--- a/Ctlg.Service/Commands/RestoreCommand.cs
+++ b/Ctlg.Service/Commands/RestoreCommand.cs
@@ -27,6 +27,11 @@ namespace Ctlg.Service.Commands
         public void Execute()
         {
             var snapshotPath = SnapshotService.FindSnapshotPath(Name, Date);
+            if (string.IsNullOrEmpty(snapshotPath))
+            {
+                throw new Exception($"Snapshot {Name} is not found");
+            }
+
             var snapshotRecords = SnapshotService.ReadSnapshotFile(snapshotPath);
             foreach (var record in snapshotRecords)
             {

--- a/Ctlg.Service/SnapshotService.cs
+++ b/Ctlg.Service/SnapshotService.cs
@@ -72,6 +72,10 @@ namespace Ctlg.Service
             }
 
             var fileName = SelectSnapshotByDate(allSnapshots, snapshotDate);
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return null;
+            }
 
             return FilesystemService.CombinePath(SnapshotsDirectory, snapshotName, fileName);
         }
@@ -116,14 +120,17 @@ namespace Ctlg.Service
             }
             else
             {
-                var date = DateTime.Parse(snapshotDate);
-                var snapshotDateFormatted = FormatSnapshotName(date);
-                return snapshots.Last(s => string.Compare(s, snapshotDateFormatted) <= 0);
+                var foundFiles = snapshots.Where(s => s.StartsWith(snapshotDate, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                if (foundFiles.Count > 1)
+                {
+                    throw new Exception(
+                        $"Provided snapshot date is ambiguous. {foundFiles.Count} snapshots exist: {string.Join(", ", foundFiles)}.");
+                }
+                return foundFiles.FirstOrDefault();
             }
         }
 
         private IFilesystemService FilesystemService { get; }
         private ICtlgService CtlgService { get; }
-        private IIndex<string, IHashFunction> HashFunctions { get; }
     }
 }

--- a/Ctlg.UnitTests/RestoreCommandTests.cs
+++ b/Ctlg.UnitTests/RestoreCommandTests.cs
@@ -11,6 +11,19 @@ namespace Ctlg.UnitTests
     public class RestoreCommandTests: BackupTestFixture
     {
         [Test]
+        public void Execute_WhenSnapshotNotFound_ThrowsException()
+        {
+            using (var mock = AutoMock.GetLoose())
+            {
+                mock.SetupFindSnapshotFile(BackupName, null);
+
+                Assert.That(() => Execute(mock),
+                    Throws.TypeOf<Exception>()
+                        .With.Message.Contain($"Snapshot {BackupName} is not found"));
+            }
+        }
+
+        [Test]
         public void Execute_WhenBackupFileNotFound_RaisesExceptionEvent()
         {
             using (var mock = AutoMock.GetLoose())

--- a/Ctlg.UnitTests/SnapshotServiceTests.cs
+++ b/Ctlg.UnitTests/SnapshotServiceTests.cs
@@ -13,7 +13,7 @@ namespace Ctlg.UnitTests
     public class SnapshotServiceTests : BackupTestFixture
     {
         [Test]
-        public void FindSnapshotFile_WithoutDate_ReturnsLatest()
+        public void FindSnapshotPath_WithoutDate_ReturnsLatest()
         {
             using (var mock = AutoMock.GetLoose())
             {
@@ -25,31 +25,55 @@ namespace Ctlg.UnitTests
         }
 
         [Test]
-        public void FindSnapshotFile_WithExactDate()
+        public void FindSnapshotPath_WithExactDate()
         {
             using (var mock = AutoMock.GetLoose())
             {
                 var service = CreateService(mock);
 
-                var snapshotPath = service.FindSnapshotPath("Test", "2019-01-01T00:00:00");
+                var snapshotPath = service.FindSnapshotPath("Test", "2019-01-01_00-00-00");
                 Assert.That(snapshotPath, Is.EqualTo("X:\\current-directory\\snapshots\\Test\\2019-01-01_00-00-00"));
             }
         }
 
         [Test]
-        public void FindSnapshotFile_WithDate_ReturnsNearestPrevious()
+        public void FindSnapshotPath_WithOneDateMatching()
         {
             using (var mock = AutoMock.GetLoose())
             {
                 var service = CreateService(mock);
 
-                var snapshotPath = service.FindSnapshotPath("Test", "2019-01-01T05:00:30");
+                var snapshotPath = service.FindSnapshotPath("Test", "2019-01-01_02");
                 Assert.That(snapshotPath, Is.EqualTo("X:\\current-directory\\snapshots\\Test\\2019-01-01_02-30-00"));
             }
         }
 
         [Test]
-        public void FindSnapshotFile_WhenSnapshotDoesNotExist_ReturnsNull()
+        public void FindSnapshotPath_WithMoreThanOneDateMatching()
+        {
+            using (var mock = AutoMock.GetLoose())
+            {
+                var service = CreateService(mock);
+
+                Assert.That(() => service.FindSnapshotPath("Test", "2019-01-01"),
+                    Throws.InstanceOf<Exception>().With.Message.Contain("date is ambiguous"));
+            }
+        }
+
+        [Test]
+        public void FindSnapshotPath_WhenNoSnapshotMatchesProvidedDate_ReturnsNull()
+        {
+            using (var mock = AutoMock.GetLoose())
+            {
+                var service = CreateService(mock);
+
+                var snapshotPath = service.FindSnapshotPath("Test", "2019-09-03");
+                Assert.That(snapshotPath, Is.Null);
+            }
+        }
+
+        [Test]
+        public void FindSnapshotPath_WhenSnapshotDoesNotExist_ReturnsNull()
         {
             using (var mock = AutoMock.GetLoose())
             {

--- a/Ctlg/Program.cs
+++ b/Ctlg/Program.cs
@@ -65,7 +65,14 @@ namespace Ctlg
         {
             var command = Mapper.Map<T>(options);
 
-            command.Execute();
+            try
+            {
+                command.Execute();
+            }
+            catch (Exception ex)
+            {
+                DomainEvents.Raise(new ErrorEvent(ex));
+            }
         }
 
         private static IContainer BuildIocContainer()

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Size in bytes.
     -n <mask>
     --name <mask>
 
-Include files by name matching <mask>.
+Include files by name matching `<mask>`.
 
 ### list
 
@@ -88,7 +88,7 @@ Backup name. Required.
     -s <mask>
     --search <mask>
 
-Include files by name matching <mask>.
+Include files by name matching `<mask>`.
 
     -f
     --fast
@@ -111,7 +111,8 @@ Backup name. Required.
     -d <date>
     --date <date>
 
-Date when backup was taken. When there is no exact match, finds most recent backup that was taken before the <date>.
+Date when backup was taken in `yyyy-MM-dd_HH-mm-ss` format. It is possible to skip date parts from the right e.g.
+`yyyy-MM-dd_HH-mm`, `yyyy-MM-dd` are laso valid.
 
 
 ## Implementation details

--- a/tests/catalog.bats
+++ b/tests/catalog.bats
@@ -7,13 +7,13 @@ load helper
   $CTLG_EXECUTABLE add $CTLG_FILESDIR
 
   output=$($CTLG_EXECUTABLE find -c 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 -f sha-256)
-  [[ "${output}" == *"hi.txt"* ]]
+  [[ "${output}" == *"hi.txt"* ]] || false
 
   output=$($CTLG_EXECUTABLE list)
-  [[ "${output}" == *"hi.txt"* ]]
+  [[ "${output}" == *"hi.txt"* ]] || false
 
   output=$($CTLG_EXECUTABLE show 2)
-  [[ "${output}" == *"hi.txt"* ]]
+  [[ "${output}" == *"hi.txt"* ]] || false
 }
 
 @test "when adding archive it parses content" {
@@ -23,13 +23,13 @@ load helper
   $CTLG_EXECUTABLE add $CTLG_FILESDIR
 
   output=$($CTLG_EXECUTABLE find --name "hi.txt")
-  [[ "${output}" == *"hi.txt"* ]]
+  [[ "${output}" == *"hi.txt"* ]] || false
 
   output=$($CTLG_EXECUTABLE find --checksum 3610a686 --function CRC32)
-  [[ "${output}" == *"hi.txt"* ]]
+  [[ "${output}" == *"hi.txt"* ]] || false
 
   output=$($CTLG_EXECUTABLE find --size 5)
-  [[ "${output}" == *"hi.txt"* ]]
+  [[ "${output}" == *"hi.txt"* ]] || false
 }
 
 @test "add files filtering by name" {
@@ -38,5 +38,5 @@ load helper
   echo -n "test" > $CTLG_FILESDIR/test
 
   output=$($CTLG_EXECUTABLE add --search "*.txt" --function CRC32 $CTLG_FILESDIR)
-  [[ "${output}" == *"2 files found"* ]]
+  [[ "${output}" == *"2 files found"* ]] || false
 }


### PR DESCRIPTION
## Summary

* `restore` command when searches for snapshots uses exact date match.
* Fixed integration tests for older `bash` versions (https://github.com/sstephenson/bats/issues/49).
* Fixed documentation markup.