### PR TITLE
Make create-index command more robust

### DIFF
--- a/Ctlg.Service/Ctlg.Service.csproj
+++ b/Ctlg.Service/Ctlg.Service.csproj
@@ -90,6 +90,7 @@
     <Compile Include="ByteArrayComparer.cs" />
     <Compile Include="IndexFileService.cs" />
     <Compile Include="Commands\RebuildIndexCommand.cs" />
+    <Compile Include="Events\Warning.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ctlg.Core\Ctlg.Core.csproj">

--- a/Ctlg.Service/Events/Warning.cs
+++ b/Ctlg.Service/Events/Warning.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace Ctlg.Service.Events
+{
+    public class Warning: IDomainEvent
+    {
+        public Warning(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+}

--- a/Ctlg.Service/IndexService.cs
+++ b/Ctlg.Service/IndexService.cs
@@ -6,8 +6,17 @@ namespace Ctlg.Service
 {
     public class IndexService: IIndexService
     {
+        public IndexService(int hashLength)
+        {
+            HashLength = hashLength;
+        }
+
         public void Add(byte[] hash)
         {
+            if (hash.Length != HashLength)
+            {
+                throw new Exception($"Hash is {hash.Length} bytes. Expected hash to have lenght {HashLength} bytes.");
+            }
             _set.Add(hash);
         }
 
@@ -17,5 +26,7 @@ namespace Ctlg.Service
         }
 
         private SortedSet<byte[]> _set = new SortedSet<byte[]>(new ByteArrayComparer());
+
+        private readonly int HashLength;
     }
 }

--- a/Ctlg.UnitTests/IndexServiceTests.cs
+++ b/Ctlg.UnitTests/IndexServiceTests.cs
@@ -10,12 +10,23 @@ namespace Ctlg.UnitTests
         [Test]
         public void GetAllHashes_Returns_PreviouslyAddedHashes()
         {
-            var service = new IndexService();
+            var service = new IndexService(1);
 
             service.Add(new byte[] { 0x2 });
             service.Add(new byte[] { 0x1 });
 
             Assert.That(service.GetAllHashes(), Is.EquivalentTo(new[] { new byte[] { 0x1 }, new byte[] { 0x2 } }));
+        }
+
+        [Test]
+        public void Add_WhenHashHasUnexpectedLength_ThrowsException()
+        {
+            var service = new IndexService(1);
+            var hash = new byte[] { 1, 2 };
+
+            Assert.That(() => service.Add(hash),
+                Throws.InstanceOf<Exception>()
+                    .With.Message.Contain("Expected hash to have lenght 1 bytes"));
         }
     }
 }

--- a/Ctlg.UnitTests/RebuildIndexCommandTests.cs
+++ b/Ctlg.UnitTests/RebuildIndexCommandTests.cs
@@ -1,45 +1,115 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Autofac.Extras.Moq;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Service;
 using Ctlg.Service.Commands;
+using Ctlg.Service.Events;
+using Ctlg.Service.Utils;
 using Moq;
 using NUnit.Framework;
 
 namespace Ctlg.UnitTests
 {
     [TestFixture]
-    public class RebuildIndexCommandTests
+    public class RebuildIndexCommandTests: BaseTestFixture
     {
+        private AutoMock AutoMock;
+        private Mock<IIndexService> IndexServiceMock;
+        private Mock<IIndexFileService> IndexFileServiceMock;
+        private string Dir1;
+        private string Dir2;
+        private string File1;
+        private string File2;
+        private string File3;
+        private IList<Warning> Warnings;
+
+        [SetUp]
+        public void Setup()
+        {
+            AutoMock = AutoMock.GetLoose();
+
+            IndexServiceMock = AutoMock.Mock<IIndexService>();
+            IndexFileServiceMock = AutoMock.Mock<IIndexFileService>();
+
+            Dir1 = "aa";
+            Dir2 = "bb";
+            File1 = "aa0002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+            File2 = "aa0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+            File3 = "bb0202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+            Warnings = SetupEvents<Warning>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AutoMock.Dispose();
+        }
+
         [Test]
         public void Execute_AddsHashesToIndex()
         {
-            using (var mock = AutoMock.GetLoose())
+            SetupStorageDir();
+
+            ExecuteCommand();
+
+            VerifyIndexSerivceAdd(File1, File2, File3).VerifyNoOtherCalls();
+            IndexFileServiceMock.Verify(s => s.Save(), Times.Once);
+        }
+
+        [Test]
+        public void Execute_SkipsFilesWithIncorrectNames()
+        {
+            File2 = "foo";
+            SetupStorageDir();
+
+            ExecuteCommand();
+
+            VerifyIndexSerivceAdd(File1, File3).VerifyNoOtherCalls();
+            Assert.That(Warnings.Any(w => w.Message.Contains("Unexpected file in storage: foo")));
+        }
+
+        [Test]
+        public void Execute_SkipsDirectoriesWithIncorrectNames()
+        {
+            Dir2 = "foo";
+            SetupStorageDir();
+
+            ExecuteCommand();
+
+            VerifyIndexSerivceAdd(File1, File2).VerifyNoOtherCalls();
+            Assert.That(Warnings.Any(w => w.Message.Contains("Unexpected directory in storage: foo")));
+        }
+
+        private void SetupStorageDir()
+        {
+            AutoMock.Mock<ICtlgService>().SetupGet(s => s.FileStorageDirectory).Returns("files-dir");
+
+            var dir1 = MockHelper.MockDirectory(Dir1, new File[] { new File(File1), new File(File2) });
+            var dir2 = MockHelper.MockDirectory(Dir2, new File[] { new File(File3) });
+            var filesDir = MockHelper.MockDirectory("files-dir", null, new IFilesystemDirectory[] { dir1, dir2 });
+
+            AutoMock.Mock<IFilesystemService>().Setup(s => s.GetDirectory(It.Is<string>(p => p == "files-dir"))).Returns(filesDir);
+        }
+
+        private Mock<IIndexService> VerifyIndexSerivceAdd(params string[] hashes)
+        {
+            foreach (var hash in hashes)
             {
-                mock.Mock<ICtlgService>()
-                    .SetupGet(s => s.FileStorageDirectory).Returns("files-dir");
-
-                var dir1 = MockHelper.MockDirectory("aa", new File[] { new File("aa01"), new File("aa02") });
-                var dir2 = MockHelper.MockDirectory("bb", new File[] { new File("bb01") });
-                var filesDir = MockHelper.MockDirectory("files-dir", null, new IFilesystemDirectory[] { dir1, dir2 });
-
-                mock.Mock<IFilesystemService>().Setup(s => s.GetDirectory(It.Is<string>(p => p == "files-dir"))).Returns(filesDir);
-
-                var indexService = mock.Mock<IIndexService>();
-                var indexFileService = mock.Mock<IIndexFileService>();
-
-                indexService.Setup(s => s.Add(new byte[] { 0xaa, 0x1 }));
-                indexService.Setup(s => s.Add(new byte[] { 0xaa, 0x2 }));
-                indexService.Setup(s => s.Add(new byte[] { 0xbb, 0x1 }));
-
-                var command = mock.Create<RebuildIndexCommand>();
-                command.Execute();
-
-                indexService.VerifyAll();
-                indexFileService.Verify(s => s.Save(), Times.Once);
+                var bytes = FormatBytes.ToByteArray(hash);
+                IndexServiceMock.Verify(s => s.Add(bytes));
             }
+
+            return IndexServiceMock;
+        }
+
+        private void ExecuteCommand()
+        {
+            var command = AutoMock.Create<RebuildIndexCommand>();
+            command.Execute();
         }
     }
 }

--- a/Ctlg/EventHandlers/ConsoleOutput.cs
+++ b/Ctlg/EventHandlers/ConsoleOutput.cs
@@ -20,7 +20,8 @@ namespace Ctlg.EventHandlers
         IHandle<CatalogEntryFound>,
         IHandle<BackupEntryCreated>,
         IHandle<BackupEntryRestored>,
-        IHandle<BackupCommandStarted>
+        IHandle<BackupCommandStarted>,
+        IHandle<Warning>
     {
         public void Handle(DirectoryFound args)
         {
@@ -155,6 +156,15 @@ namespace Ctlg.EventHandlers
         public string FormatSnapshotRecord(SnapshotRecord record)
         {
             return $"{record.Hash.Substring(0, 8)} {FileSize.Format(record.Size),6} {record.Name}";
+        }
+
+        public void Handle(Warning args)
+        {
+            using (new ConsoleTextAttributesScope())
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine(args.Message);
+            }
         }
 
         private int _filesFound = 0;

--- a/Ctlg/Program.cs
+++ b/Ctlg/Program.cs
@@ -102,7 +102,7 @@ namespace Ctlg
 
             builder.RegisterType<CtlgContext>().As<ICtlgContext>().InstancePerLifetimeScope();
             builder.RegisterType<CtlgService>().As<ICtlgService>().InstancePerLifetimeScope();
-            builder.RegisterType<IndexService>().As<IIndexService>().InstancePerLifetimeScope();
+            builder.RegisterType<IndexService>().WithParameter("hashLength", 32).As<IIndexService>().InstancePerLifetimeScope();
             builder.RegisterType<IndexFileService>().As<IIndexFileService>().InstancePerLifetimeScope();
 
             var genericHandlerType = typeof(IHandle<>);

--- a/tests/index.bats
+++ b/tests/index.bats
@@ -5,14 +5,26 @@ load helper
 @test "index recreate" {
   echo -n "hi" > "$CTLG_FILESDIR/hi.txt"
   echo -n "hello" > "$CTLG_FILESDIR/hello.txt"
-  $CTLG_EXECUTABLE backup -n Test ${CTLG_FILESDIR}
+  $CTLG_EXECUTABLE backup -n Test "$CTLG_FILESDIR"
 
   sum1="\x2c\xf2\x4d\xba\x5f\xb0\xa3\x0e\x26\xe8\x3b\x2a\xc5\xb9\xe2\x9e\x1b\x16\x1e\x5c\x1f\xa7\x42\x5e\x73\x04\x33\x62\x93\x8b\x98\x24"
   sum2="\x8f\x43\x43\x46\x64\x8f\x6b\x96\xdf\x89\xdd\xa9\x01\xc5\x17\x6b\x10\xa6\xd8\x39\x61\xdd\x3c\x1a\xc8\x8b\x59\xb2\xdc\x32\x7a\xa4"
 
-  echo -n -e "$sum1$sum2" > "${CTLG_FILESDIR}/expected-index.bin"
+  echo -n -e "$sum1$sum2" > "$CTLG_FILESDIR/expected-index.bin"
 
-  ${CTLG_EXECUTABLE} rebuild-index
+  $CTLG_EXECUTABLE rebuild-index
 
-  diff "$CTLG_WORKDIR/index.bin" "${CTLG_FILESDIR}/expected-index.bin"
+  diff "$CTLG_WORKDIR/index.bin" "$CTLG_FILESDIR/expected-index.bin"
+}
+
+@test "index recreate with warnings" {
+  mkdir "$CTLG_WORKDIR/file_storage"
+  mkdir "$CTLG_WORKDIR/file_storage/foo"
+  mkdir "$CTLG_WORKDIR/file_storage/00"
+  touch "$CTLG_WORKDIR/file_storage/00/bar"
+
+  run $CTLG_EXECUTABLE rebuild-index
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unexpected directory in storage: foo"* ]] || false
+  [[ "$output" == *"Unexpected file in storage: bar"* ]] || false
 }


### PR DESCRIPTION
## Summary

* Improves `create-index` command: adds name validations when enumerating files and directories in file storage.
* `IndexService` is restricted to only work with hashes of the same length.