### PR TITLE
Improve file and directory enumeration

### DIFF
--- a/Ctlg.Filesystem/FilesystemDirectory.cs
+++ b/Ctlg.Filesystem/FilesystemDirectory.cs
@@ -34,10 +34,10 @@ namespace Ctlg.Filesystem
                 RecordUpdatedDateTime = DateTime.UtcNow
             };
         }
-        
+
         public IEnumerable<IFilesystemDirectory> EnumerateDirectories()
         {
-            foreach (var directoryInfo in _directoryInfo.GetDirectories())
+            foreach (var directoryInfo in _directoryInfo.EnumerateDirectories())
             {
                 var dir = new FilesystemDirectory(directoryInfo);
                 dir.Directory.RelativePath = CombineRelativePath(directoryInfo.Name);
@@ -48,7 +48,7 @@ namespace Ctlg.Filesystem
 
         public IEnumerable<File> EnumerateFiles(string searchPattern)
         {
-            foreach (var fileInfo in _directoryInfo.GetFiles(searchPattern))
+            foreach (var fileInfo in _directoryInfo.EnumerateFiles(searchPattern))
             {
                 var file = CreateFilesystemEntry(fileInfo);
                 file.RelativePath = CombineRelativePath(fileInfo.Name);

--- a/Ctlg.Filesystem/FilesystemDirectoryLongPath.cs
+++ b/Ctlg.Filesystem/FilesystemDirectoryLongPath.cs
@@ -36,7 +36,7 @@ namespace Ctlg.Filesystem
 
         public IEnumerable<IFilesystemDirectory> EnumerateDirectories()
         {
-            foreach (var directoryInfo in _directoryInfo.GetDirectories())
+            foreach (var directoryInfo in _directoryInfo.EnumerateDirectories())
             {
                 var dir = new FilesystemDirectoryLongPath(directoryInfo);
                 dir.Directory.RelativePath = CombineRelativePath(directoryInfo.Name);
@@ -47,7 +47,7 @@ namespace Ctlg.Filesystem
 
         public IEnumerable<File> EnumerateFiles(string searchPattern)
         {
-            foreach (var fileInfo in _directoryInfo.GetFiles(searchPattern))
+            foreach (var fileInfo in _directoryInfo.EnumerateFiles(searchPattern))
             {
                 var file = CreateFilesystemEntry(fileInfo);
                 file.RelativePath = CombineRelativePath(fileInfo.Name);


### PR DESCRIPTION
## Summary

Use `IEnumerable` interface  instead of arrays to get files and directories from `DirectoryInfo`. 