### PR TITLE
Use index in backup command

### DIFF
--- a/Ctlg.Service/Commands/BackupCommand.cs
+++ b/Ctlg.Service/Commands/BackupCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Service.Events;
 
@@ -12,15 +11,19 @@ namespace Ctlg.Service.Commands
         public string SearchPattern { get; set; }
         public bool IsFastMode { get; set; }
 
-        public BackupCommand(ITreeProvider treeProvider, ISnapshotService snapshotService, ISnapshotReader snapshotReader, ICtlgService ctlgService)
+        public BackupCommand(ITreeProvider treeProvider, ISnapshotReader snapshotReader, ICtlgService ctlgService,
+            IIndexFileService indexFileService)
         {
             TreeProvider = treeProvider;
             SnapshotReader = snapshotReader;
             CtlgService = ctlgService;
+            IndexFileService = indexFileService;
         }
 
         public void Execute()
         {
+            IndexFileService.Load();
+
             var root = TreeProvider.ReadTree(Path, SearchPattern);
 
             if (IsFastMode)
@@ -35,11 +38,14 @@ namespace Ctlg.Service.Commands
                 treeWalker.Walk(writer.AddFile);
             }
 
+            IndexFileService.Save();
+
             DomainEvents.Raise(new BackupCommandEnded());
         }
 
         private ITreeProvider TreeProvider { get; set; }
         private ICtlgService CtlgService { get; set; }
+        private IIndexFileService IndexFileService { get; set; }
         private ISnapshotReader SnapshotReader { get; set; }
     }
 }

--- a/Ctlg.Service/Commands/SnapshotReader.cs
+++ b/Ctlg.Service/Commands/SnapshotReader.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using StreamReader = System.IO.StreamReader;
 using Ctlg.Core;
-using Ctlg.Service.Events;
 using Ctlg.Service.Utils;
 using Ctlg.Core.Interfaces;
 
@@ -35,7 +33,7 @@ namespace Ctlg.Service.Commands
             }
         }
 
-        private void ProcessRecord(SnapshotRecord record, Core.File root)
+        private void ProcessRecord(SnapshotRecord record, File root)
         {
             var path = record.Name.Split('\\', '/');
 

--- a/Ctlg.Service/CtlgService.cs
+++ b/Ctlg.Service/CtlgService.cs
@@ -12,11 +12,14 @@ namespace Ctlg.Service
 {
     public class CtlgService : ICtlgService
     {
-        public CtlgService(IDataService dataService, IFilesystemService filesystemService, ISnapshotService snapshotService, IIndex<string, IHashFunction> hashFunction, IComponentContext componentContext)
+        public CtlgService(IDataService dataService, IFilesystemService filesystemService,
+            ISnapshotService snapshotService, IIndexService indexService,
+            IIndex<string, IHashFunction> hashFunction, IComponentContext componentContext)
         {
             DataService = dataService;
             FilesystemService = filesystemService;
             SnapshotService = snapshotService;
+            IndexService = indexService;
             HashFunctions = hashFunction;
             ComponentContext = componentContext;
 
@@ -108,6 +111,9 @@ namespace Ctlg.Service
             var backupFileDir = FilesystemService.GetDirectoryName(backupFile);
             FilesystemService.CreateDirectory(backupFileDir);
             FilesystemService.Copy(file.FullPath, backupFile);
+
+            var hash = file.Hashes.First(h => h.HashAlgorithmId == (int)HashAlgorithmId.SHA256);
+            IndexService.Add(hash.Value);
         }
 
         public Hash CalculateHashForFile(File file, IHashFunction hashFunction)
@@ -182,6 +188,7 @@ namespace Ctlg.Service
         private IDataService DataService { get; }
         private IFilesystemService FilesystemService { get; }
         private ISnapshotService SnapshotService { get; set; }
+        private IIndexService IndexService { get; set; }
         private IIndex<string, IHashFunction> HashFunctions { get; set; }
         private IComponentContext ComponentContext { get; set; }
         private IComparer<File> FileNameComparer { get; } = new FileNameComparer();

--- a/Ctlg.Service/IndexFileService.cs
+++ b/Ctlg.Service/IndexFileService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Ctlg.Core.Interfaces;
+using Ctlg.Service.Events;
 
 namespace Ctlg.Service
 {
@@ -27,24 +28,35 @@ namespace Ctlg.Service
 
         public void Load()
         {
-            using (var reader = new BinaryReader(FilesystemService.OpenFileForRead(CtlgService.IndexPath)))
+            try
             {
-                while (true)
+                using (var reader = new BinaryReader(FilesystemService.OpenFileForRead(CtlgService.IndexPath)))
                 {
-                    var hash = reader.ReadBytes(HashLength);
-                    if (hash.Length == HashLength)
+                    while (true)
                     {
-                        IndexService.Add(hash);
-                    }
-                    else if(hash.Length == 0)
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        throw new Exception($"Corrupted index file.");
+                        var hash = reader.ReadBytes(HashLength);
+                        if (hash.Length == HashLength)
+                        {
+                            IndexService.Add(hash);
+                        }
+                        else if (hash.Length == 0)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            throw new Exception($"Corrupted index file.");
+                        }
                     }
                 }
+            }
+            catch (FileNotFoundException)
+            {
+                // Ignore exception. Index file does not exist on the first run.
+            }
+            catch (Exception)
+            {
+                throw;
             }
         }
 

--- a/Ctlg/EventHandlers/ConsoleOutput.cs
+++ b/Ctlg/EventHandlers/ConsoleOutput.cs
@@ -7,8 +7,8 @@ using Ctlg.Service.Utils;
 
 namespace Ctlg.EventHandlers
 {
-    public class ConsoleOutput : 
-        IHandle<FileFound>, 
+    public class ConsoleOutput :
+        IHandle<FileFound>,
         IHandle<DirectoryFound>,
         IHandle<ArchiveFound>,
         IHandle<ArchiveEntryFound>,
@@ -137,7 +137,7 @@ namespace Ctlg.EventHandlers
             }
 
             var h = args.HashCalculated ? 'H' : ' ';
-            var n = args.NewFileAddedToStorage ? 'N' : ' ';
+            var n = args.IsHashFoundInIndex ? 'I' : args.NewFileAddedToStorage ? 'N' : ' ';
 
             var maxCounterLength = _filesFound.ToString().Length;
             var counter = _filesProcessed.ToString().PadLeft(maxCounterLength);

--- a/tests/backup.bats
+++ b/tests/backup.bats
@@ -35,6 +35,20 @@ load helper
   $CTLG_EXECUTABLE backup -f -n Test "$CTLG_FILESDIR"
 }
 
+@test "bakup in fast mode uses index" {
+  echo -n "hello" > "$CTLG_FILESDIR/hi.txt"
+  $CTLG_EXECUTABLE backup -n Test "$CTLG_FILESDIR"
+
+  cp "$CTLG_FILESDIR/hi.txt" "$CTLG_FILESDIR/hello.txt"
+
+  rm "$CTLG_WORKDIR/file_storage/2c/2cf24dba"*
+
+  output=$($CTLG_EXECUTABLE backup -f -n Test "${CTLG_FILESDIR}")
+
+  [[ "${output}" == *"1/2 HI 2cf24dba      5 hello.txt"* ]] || false
+  [[ "${output}" == *"2/2  I 2cf24dba      5 hi.txt"* ]] || false
+}
+
 @test "backup and restore multiple files and directories" {
   echo -n "hello" > "$CTLG_FILESDIR/hi.txt"
   mkdir "$CTLG_FILESDIR/foo"


### PR DESCRIPTION
## Summary

* `backup` command now updates index - adds new file hashes. This keeps index in sync with the file storage. No need to rebuild index for backup to work in fast mode.
* In `backup` command output:  files found in index have `I` flag that means that file is not added to the storage because it was indexed.