### PR TITLE
Use index in pull-backup command

### DIFF
--- a/Ctlg.UnitTests/BackupPullCommandTests.cs
+++ b/Ctlg.UnitTests/BackupPullCommandTests.cs
@@ -53,7 +53,9 @@ namespace Ctlg.UnitTests
 
             Assert.That(File.FullPath, Is.EqualTo(FileFullPath));
             BackupWriterMock.Verify(m => m.AddFile(File), Times.Once);
-        }
 
+            IndexFileServiceMock.Verify(s => s.Load(), Times.Once);
+            IndexFileServiceMock.Verify(s => s.Save(), Times.Once);
+        }
     }
 }

--- a/Ctlg/EventHandlers/ConsoleOutput.cs
+++ b/Ctlg/EventHandlers/ConsoleOutput.cs
@@ -142,7 +142,9 @@ namespace Ctlg.EventHandlers
             var maxCounterLength = _filesFound.ToString().Length;
             var counter = _filesProcessed.ToString().PadLeft(maxCounterLength);
 
-            Console.WriteLine($"{counter}/{_filesFound} {h}{n} {FormatSnapshotRecord(args.BackupEntry)}");
+            var filesFound = 0 < _filesFound ? $"/{_filesFound}" : "";
+
+            Console.WriteLine($"{counter}{filesFound} {h}{n} {FormatSnapshotRecord(args.BackupEntry)}");
         }
 
         public void Handle(BackupEntryRestored args)
@@ -154,8 +156,8 @@ namespace Ctlg.EventHandlers
 
         public void Handle(BackupCommandEnded args)
         {
-            Console.WriteLine($"Processed: {FileSize.Format(bytesProcessed)}");
-            Console.WriteLine($"Added to storage: {FileSize.Format(bytesAddedToStorage)}");
+            Console.WriteLine($"Processed: {FileSize.Format(bytesProcessed)}B");
+            Console.WriteLine($"Added to storage: {FileSize.Format(bytesAddedToStorage)}B");
         }
 
         public void Handle(Warning args)

--- a/tests/backup-pull.bats
+++ b/tests/backup-pull.bats
@@ -19,4 +19,5 @@ load helper
 
   $CTLG_EXECUTABLE restore -n Test "$CTLG_RESTOREDIR"
   diff -r "$CTLG_FILESDIR" "$CTLG_RESTOREDIR"
+  diff "$CTLG_WORKDIR/backup1/index.bin" "$CTLG_WORKDIR/backup2/index.bin"
 }


### PR DESCRIPTION
## Summary

* `pull-backup` command uses index.
* Improved console output for file list in `pull-backup` command.