### PR TITLE
Add support for comments in snapshot files

### DIFF
--- a/Ctlg.Service/Services/SnapshotService.cs
+++ b/Ctlg.Service/Services/SnapshotService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Service.Events;
@@ -18,6 +19,8 @@ namespace Ctlg.Service.Services
             FilesystemService = filesystemService;
 
             CurrentDirectory = FilesystemService.GetCurrentDirectory();
+
+            CommentLineRegex = new Regex(@"^\s*#");
         }
 
         public IEnumerable<SnapshotRecord> ReadSnapshotFile(string path)
@@ -32,7 +35,10 @@ namespace Ctlg.Service.Services
                         SnapshotRecord snapshotRecord = null;
                         try
                         {
-                            snapshotRecord = new SnapshotRecord(line);
+                            if (!CommentLineRegex.IsMatch(line))
+                            {
+                                snapshotRecord = new SnapshotRecord(line);
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -155,5 +161,6 @@ namespace Ctlg.Service.Services
         }
 
         private IFilesystemService FilesystemService { get; }
+        private Regex CommentLineRegex { get; }
     }
 }

--- a/Ctlg.UnitTests/SnapshotServiceTests.cs
+++ b/Ctlg.UnitTests/SnapshotServiceTests.cs
@@ -15,6 +15,7 @@ namespace Ctlg.UnitTests
         private readonly string Hash = "64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c";
         private readonly string FilePath = "1.txt";
         private readonly string FileListLine;
+        private readonly string CommentLine = "# Comment";
         private readonly string RootDirectory = "X:\\some-directory";
         private readonly string Date1 = "2019-01-01_00-00-00";
         private readonly string Date2 = "2019-01-01_02-30-00";
@@ -132,6 +133,19 @@ namespace Ctlg.UnitTests
 
             Assert.That(records.Count, Is.EqualTo(1));
             Assert.That(records[0].ToString(), Is.EqualTo(FileListLine));
+        }
+
+        [Test]
+        public void ReadSnapshotFile_FileContainsComment_ReturnsSnapshotRecords()
+        {
+            AutoMock.SetupOpenFileForRead(SnapshotFile3, $"{CommentLine}\n{FileListLine}");
+            var errors = SetupEvents<ErrorEvent>();
+
+            var records = SnapshotService.ReadSnapshotFile(SnapshotFile3).ToList();
+
+            Assert.That(records.Count, Is.EqualTo(1));
+            Assert.That(records[0].ToString(), Is.EqualTo(FileListLine));
+            Assert.That(errors.Count, Is.EqualTo(0));
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Snapshot files now can have comment lines. A line that begins with `#` is considered a comment and is ignored by the application.