### PR TITLE
Show more relevant error messages for pull-backup command

### DIFF
--- a/Ctlg.Service/Commands/BackupPullCommand.cs
+++ b/Ctlg.Service/Commands/BackupPullCommand.cs
@@ -25,6 +25,11 @@ namespace Ctlg.Service.Commands
             IndexFileService.Load();
 
             var snapshotFile = SnapshotService.FindSnapshotFile(Path, Name, Date);
+            if (snapshotFile == null)
+            {
+                throw new Exception($"Snapshot {Name} is not found in {Path}.");
+            }
+
             using (var backupWriter = CtlgService.CreateBackupWriter(snapshotFile.Name, snapshotFile.Date, false, true))
             {
                 backupWriter.AddComment($"ctlg {AppVersion.Version}");

--- a/Ctlg/EventHandlers/ErrorOutput.cs
+++ b/Ctlg/EventHandlers/ErrorOutput.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Autofac.Core;
 using Ctlg.Service;
 using Ctlg.Service.Events;
 
@@ -12,10 +13,21 @@ namespace Ctlg.EventHandlers
             {
                 Console.ForegroundColor = ConsoleColor.Red;
 
-                var message = args.Message ?? args.Exception?.Message;
+                var message = args.Message ?? GetMessage(args.Exception);
 
                 Console.Error.WriteLine(message);
             }
+        }
+
+        private string GetMessage(Exception ex)
+        {
+            var dependencyResolutionException = ex as DependencyResolutionException;
+            if (dependencyResolutionException != null)
+            {
+                return GetMessage(dependencyResolutionException.InnerException);
+            }
+
+            return ex?.Message;
         }
     }
 }

--- a/tests/backup-pull.bats
+++ b/tests/backup-pull.bats
@@ -2,7 +2,7 @@
 
 load helper
 
-@test "backup-pull imports snapshot" {
+@test "pull-backup imports snapshot" {
   echo -n "hello" > "$CTLG_FILESDIR/hi.txt"
   mkdir "$CTLG_FILESDIR/foo"
   echo -n "world" > "$CTLG_FILESDIR/foo/w.txt"
@@ -20,4 +20,15 @@ load helper
   $CTLG_EXECUTABLE restore -n Test "$CTLG_RESTOREDIR"
   diff -r "$CTLG_FILESDIR" "$CTLG_RESTOREDIR"
   diff "$CTLG_WORKDIR/backup1/index.bin" "$CTLG_WORKDIR/backup2/index.bin"
+
+  # running pull-backup second time should result in an error because destination shapshot file already exists
+  run $CTLG_EXECUTABLE pull-backup -n Test "$CTLG_WORKDIR/backup1"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"File already exists"* ]] || false
+
+  # when source snapshot does not exist
+  run $CTLG_EXECUTABLE pull-backup -n Foo "$CTLG_WORKDIR/backup1"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Snapshot Foo is not found in $CTLG_WORKDIR/backup1"* ]] || false
+
 }


### PR DESCRIPTION
## Summary

- Shows an error message when source snapshot file is not found by `pull-backup` command.
- When an exception occurs while Autofac resolves dependencies, outputs inner exception because it contains more relevant information. For example this would give a correct error message when a destination snapshot file already exists for `pull-backup` command. 

