### PR TITLE
Check hashes in pull-backup command

### DIFF
--- a/tests/backup-pull.bats
+++ b/tests/backup-pull.bats
@@ -26,9 +26,17 @@ load helper
   [ "$status" -eq 2 ]
   [[ "$output" == *"File already exists"* ]] || false
 
+  rm "$CTLG_WORKDIR/backup2/snapshots/Test/"*
+  rm "$CTLG_WORKDIR/backup2/file_storage/2c/2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
   # when source snapshot does not exist
   run $CTLG_EXECUTABLE pull-backup -n Foo "$CTLG_WORKDIR/backup1"
   [ "$status" -eq 2 ]
   [[ "$output" == *"Snapshot Foo is not found in $CTLG_WORKDIR/backup1"* ]] || false
 
+  # modifying file in storage, this will lead to a corrupted backup
+  echo -n "test1" > "$CTLG_WORKDIR/backup1/file_storage/2c/2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+  run $CTLG_EXECUTABLE pull-backup -n Test "$CTLG_WORKDIR/backup1"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Caclulated hash does not match expected"* ]] || false
 }


### PR DESCRIPTION
## Summary

`pull-backup` command copies files from source backup storage. If the checksum for a file does not match with an expected value, then backup might be corrupted. The app will not copy this file and show an error message.