### PR TITLE
Move unit tests to namespaces

### DIFF
--- a/Ctlg.UnitTests/Ctlg.UnitTests.csproj
+++ b/Ctlg.UnitTests/Ctlg.UnitTests.csproj
@@ -101,37 +101,37 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
-    <Compile Include="AddCommandTests.cs" />
-    <Compile Include="CtlgServiceTests.cs" />
-    <Compile Include="DataServiceTests.cs" />
-    <Compile Include="FileTests.cs" />
-    <Compile Include="FindCommandTests.cs" />
-    <Compile Include="HashTests.cs" />
     <Compile Include="Index.cs" />
-    <Compile Include="ListCommandTests.cs" />
-    <Compile Include="MigrationServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RestoreCommandTests.cs" />
-    <Compile Include="BaseTestFixture.cs" />
-    <Compile Include="BackupTestFixture.cs" />
     <Compile Include="MockHelper.cs" />
-    <Compile Include="BackupCommandTests.cs" />
-    <Compile Include="FileSizeTests.cs" />
-    <Compile Include="FileEnumerateTests.cs" />
-    <Compile Include="SnapshotServiceTests.cs" />
-    <Compile Include="ArchiveServiceTests.cs" />
-    <Compile Include="FilesystemServiceBaseTests.cs" />
-    <Compile Include="IndexServiceTests.cs" />
-    <Compile Include="ByteArrayComparerTests.cs" />
-    <Compile Include="IndexFileServiceTests.cs" />
-    <Compile Include="RebuildIndexCommandTests.cs" />
-    <Compile Include="SnapshotReaderTests.cs" />
-    <Compile Include="AutoMockTestFixture.cs" />
-    <Compile Include="BackupWriterTests.cs" />
-    <Compile Include="FileStorageServiceTests.cs" />
-    <Compile Include="BackupPullCommandTests.cs" />
     <Compile Include="Factories.cs" />
-    <Compile Include="CommandTestFixture.cs" />
+    <Compile Include="Fixtures\AutoMockTestFixture.cs" />
+    <Compile Include="Fixtures\BackupTestFixture.cs" />
+    <Compile Include="Tests\BackupWriterTests.cs" />
+    <Compile Include="Fixtures\BaseTestFixture.cs" />
+    <Compile Include="Tests\ByteArrayComparerTests.cs" />
+    <Compile Include="Fixtures\CommandTestFixture.cs" />
+    <Compile Include="Tests\FileSizeTests.cs" />
+    <Compile Include="Tests\FileTests.cs" />
+    <Compile Include="Tests\HashTests.cs" />
+    <Compile Include="Tests\Commands\AddCommandTests.cs" />
+    <Compile Include="Tests\Commands\BackupCommandTests.cs" />
+    <Compile Include="Tests\Commands\BackupPullCommandTests.cs" />
+    <Compile Include="Tests\Commands\FindCommandTests.cs" />
+    <Compile Include="Tests\Commands\ListCommandTests.cs" />
+    <Compile Include="Tests\Commands\RebuildIndexCommandTests.cs" />
+    <Compile Include="Tests\Commands\RestoreCommandTests.cs" />
+    <Compile Include="Tests\Commands\Steps\FileEnumerateTests.cs" />
+    <Compile Include="Tests\Commands\Steps\SnapshotReaderTests.cs" />
+    <Compile Include="Tests\Services\ArchiveServiceTests.cs" />
+    <Compile Include="Tests\Services\CtlgServiceTests.cs" />
+    <Compile Include="Tests\Services\DataServiceTests.cs" />
+    <Compile Include="Tests\Services\FileStorageServiceTests.cs" />
+    <Compile Include="Tests\Services\FilesystemServiceBaseTests.cs" />
+    <Compile Include="Tests\Services\IndexFileServiceTests.cs" />
+    <Compile Include="Tests\Services\IndexServiceTests.cs" />
+    <Compile Include="Tests\Services\MigrationServiceTests.cs" />
+    <Compile Include="Tests\Services\SnapshotServiceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -162,6 +162,13 @@
       <Project>{9d3b1072-a9ed-476e-b68b-1f7c5fac58ef}</Project>
       <Name>Ctlg</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tests\" />
+    <Folder Include="Fixtures\" />
+    <Folder Include="Tests\Commands\" />
+    <Folder Include="Tests\Commands\Steps\" />
+    <Folder Include="Tests\Services\" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Ctlg.UnitTests/Fixtures/AutoMockTestFixture.cs
+++ b/Ctlg.UnitTests/Fixtures/AutoMockTestFixture.cs
@@ -2,7 +2,7 @@
 using Autofac.Extras.Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Fixtures
 {
     public abstract class AutoMockTestFixture : BaseTestFixture
     {

--- a/Ctlg.UnitTests/Fixtures/BackupTestFixture.cs
+++ b/Ctlg.UnitTests/Fixtures/BackupTestFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Ctlg.Core;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Fixtures
 {
     public abstract class BackupTestFixture: BaseTestFixture
     {

--- a/Ctlg.UnitTests/Fixtures/BaseTestFixture.cs
+++ b/Ctlg.UnitTests/Fixtures/BaseTestFixture.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Ctlg.Service;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Fixtures
 {
     [TestFixture]
     public abstract class BaseTestFixture

--- a/Ctlg.UnitTests/Fixtures/CommandTestFixture.cs
+++ b/Ctlg.UnitTests/Fixtures/CommandTestFixture.cs
@@ -5,7 +5,7 @@ using Ctlg.Service.Commands;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Fixtures
 {
     public abstract class CommandTestFixture<S>: AutoMockTestFixture where S: ICommand
     {

--- a/Ctlg.UnitTests/Tests/BackupWriterTests.cs
+++ b/Ctlg.UnitTests/Tests/BackupWriterTests.cs
@@ -10,8 +10,9 @@ using System.Linq;
 using Ctlg.Core.Interfaces;
 using System.Collections.Generic;
 using Ctlg.Service.Events;
+using Ctlg.UnitTests.Fixtures;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests
 {
     public class BackupWriterTests : AutoMockTestFixture
     {

--- a/Ctlg.UnitTests/Tests/ByteArrayComparerTests.cs
+++ b/Ctlg.UnitTests/Tests/ByteArrayComparerTests.cs
@@ -2,7 +2,7 @@
 using Ctlg.Service;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests
 {
     [TestFixture]
     public class ByteArrayComparerTests

--- a/Ctlg.UnitTests/Tests/Commands/AddCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/AddCommandTests.cs
@@ -1,12 +1,11 @@
 ﻿using Autofac.Extras.Moq;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
-using Ctlg.Service;
 using Ctlg.Service.Commands;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     [TestFixture]
     public class AddCommandTests

--- a/Ctlg.UnitTests/Tests/Commands/BackupCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/BackupCommandTests.cs
@@ -5,10 +5,11 @@ using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Service.Commands;
 using Ctlg.Service.Events;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     public class BackupCommandTests: CommandTestFixture<BackupCommand>
     {

--- a/Ctlg.UnitTests/Tests/Commands/BackupPullCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/BackupPullCommandTests.cs
@@ -5,8 +5,9 @@ using Ctlg.Service.Commands;
 using NUnit.Framework;
 using Moq;
 using Ctlg.Core.Interfaces;
+using Ctlg.UnitTests.Fixtures;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     public class BackupPullCommandTests: CommandTestFixture<BackupPullCommand>
     {

--- a/Ctlg.UnitTests/Tests/Commands/FindCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/FindCommandTests.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
-using Ctlg.Service;
 using Ctlg.Service.Commands;
 using Ctlg.Service.Utils;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     [TestFixture]
     public class FindCommandTests

--- a/Ctlg.UnitTests/Tests/Commands/ListCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/ListCommandTests.cs
@@ -3,7 +3,7 @@ using Ctlg.Service.Commands;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     [TestFixture]
     public class ListCommandTests

--- a/Ctlg.UnitTests/Tests/Commands/RebuildIndexCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/RebuildIndexCommandTests.cs
@@ -4,14 +4,14 @@ using System.Linq;
 using Autofac.Extras.Moq;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
-using Ctlg.Service;
 using Ctlg.Service.Commands;
 using Ctlg.Service.Events;
 using Ctlg.Service.Utils;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     public class RebuildIndexCommandTests: AutoMockTestFixture
     {

--- a/Ctlg.UnitTests/Tests/Commands/RestoreCommandTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/RestoreCommandTests.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using Autofac.Extras.Moq;
-using Ctlg.Core.Interfaces;
 using Ctlg.Service.Commands;
 using Ctlg.Service.Events;
-using Moq;
+using Ctlg.UnitTests.Fixtures;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands
 {
     public class RestoreCommandTests: BackupTestFixture
     {

--- a/Ctlg.UnitTests/Tests/Commands/Steps/FileEnumerateTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/Steps/FileEnumerateTests.cs
@@ -5,10 +5,9 @@ using Autofac.Extras.Moq;
 using Ctlg.Core.Interfaces;
 using Ctlg.Core;
 using Ctlg.Service.Commands;
-using System.Collections.Generic;
-using System.Linq;
+using Ctlg.UnitTests.Fixtures;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands.Steps
 {
     public class FileEnumerateTests: BaseTestFixture
     {

--- a/Ctlg.UnitTests/Tests/Commands/Steps/SnapshotReaderTests.cs
+++ b/Ctlg.UnitTests/Tests/Commands/Steps/SnapshotReaderTests.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using Autofac.Extras.Moq;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
-using Ctlg.Service;
 using Ctlg.Service.Commands;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Commands.Steps
 {
     public class SnapshotReaderTests : AutoMockTestFixture
     {

--- a/Ctlg.UnitTests/Tests/FileSizeTests.cs
+++ b/Ctlg.UnitTests/Tests/FileSizeTests.cs
@@ -2,7 +2,7 @@
 using Ctlg.Service.Utils;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests
 {
     [TestFixture]
     public class FileSizeTests

--- a/Ctlg.UnitTests/Tests/FileTests.cs
+++ b/Ctlg.UnitTests/Tests/FileTests.cs
@@ -2,7 +2,7 @@
 using Ctlg.Core;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests
 {
     [TestFixture]
     public class FileTests

--- a/Ctlg.UnitTests/Tests/HashTests.cs
+++ b/Ctlg.UnitTests/Tests/HashTests.cs
@@ -1,7 +1,7 @@
 ﻿using Ctlg.Core;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests
 {
     [TestFixture]
     public class HashTests

--- a/Ctlg.UnitTests/Tests/Services/ArchiveServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/ArchiveServiceTests.cs
@@ -2,12 +2,11 @@
 using System.IO;
 using System.Linq;
 using Autofac.Extras.Moq;
-using Ctlg.Core.Interfaces;
 using Ctlg.Service;
 using Ctlg.Service.Utils;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     public class ArchiveServiceTests
     {

--- a/Ctlg.UnitTests/Tests/Services/CtlgServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/CtlgServiceTests.cs
@@ -6,15 +6,15 @@ using Autofac.Extras.Moq;
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Filesystem;
-using Ctlg.Service;
 using Ctlg.Service.Commands;
 using Ctlg.Service.Events;
 using Ctlg.Service.Services;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 using File = Ctlg.Core.File;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     public class CtlgServiceTests: BaseTestFixture
     {

--- a/Ctlg.UnitTests/Tests/Services/DataServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/DataServiceTests.cs
@@ -4,7 +4,7 @@ using Ctlg.Db.Migrations;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     [TestFixture]
     public class DataServiceTests

--- a/Ctlg.UnitTests/Tests/Services/FileStorageServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/FileStorageServiceTests.cs
@@ -2,10 +2,11 @@
 using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Service.Services;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     public class FileStorageServiceTests : AutoMockTestFixture
     {

--- a/Ctlg.UnitTests/Tests/Services/FilesystemServiceBaseTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/FilesystemServiceBaseTests.cs
@@ -6,7 +6,7 @@ using Ctlg.Filesystem;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     public class FilesystemServiceBaseTests
     {

--- a/Ctlg.UnitTests/Tests/Services/IndexFileServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/IndexFileServiceTests.cs
@@ -3,12 +3,12 @@ using System.IO;
 using Autofac;
 using Autofac.Extras.Moq;
 using Ctlg.Core.Interfaces;
-using Ctlg.Service;
 using Ctlg.Service.Services;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     public class IndexFileServiceTests : AutoMockTestFixture
     {

--- a/Ctlg.UnitTests/Tests/Services/IndexServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/IndexServiceTests.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using Ctlg.Core.Interfaces;
-using Ctlg.Service;
 using Ctlg.Service.Services;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     [TestFixture]
     public class IndexServiceTests

--- a/Ctlg.UnitTests/Tests/Services/MigrationServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/MigrationServiceTests.cs
@@ -3,7 +3,7 @@ using Ctlg.Data;
 using Ctlg.Db.Migrations;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     [TestFixture]
     public class MigrationServiceTests

--- a/Ctlg.UnitTests/Tests/Services/SnapshotServiceTests.cs
+++ b/Ctlg.UnitTests/Tests/Services/SnapshotServiceTests.cs
@@ -5,10 +5,11 @@ using Ctlg.Core;
 using Ctlg.Core.Interfaces;
 using Ctlg.Service.Events;
 using Ctlg.Service.Services;
+using Ctlg.UnitTests.Fixtures;
 using Moq;
 using NUnit.Framework;
 
-namespace Ctlg.UnitTests
+namespace Ctlg.UnitTests.Tests.Services
 {
     public class SnapshotServiceTests : AutoMockTestFixture
     {


### PR DESCRIPTION
## Summary

- Move tests to `Ctlg.UnitTests.Tests.*` namespaces.
- Move fixtures `Ctlg.UnitTests.Fixtures` namespace.

This gives a better project structure.