### PR TITLE
Fix Sharing violation on exFAT in mono in macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ paket-files/
 *.sln.iml
 
 .DS_Store
+.vscode

--- a/Ctlg.Core/Interfaces/IFilesystemService.cs
+++ b/Ctlg.Core/Interfaces/IFilesystemService.cs
@@ -7,6 +7,7 @@ namespace Ctlg.Core.Interfaces
     {
         IFilesystemDirectory GetDirectory(string path);
         IEnumerable<File> EnumerateFiles(string path, string searchMask = null);
+        Stream OpenFileForWrite(string path);
         Stream OpenFileForRead(string path);
         Stream CreateNewFileForWrite(string path);
         Stream CreateFileForWrite(string path);

--- a/Ctlg.Filesystem/FileSystemServiceLongPath.cs
+++ b/Ctlg.Filesystem/FileSystemServiceLongPath.cs
@@ -78,5 +78,10 @@ namespace Ctlg.Filesystem
         {
             return File.OpenRead(path);
         }
+
+        public Stream OpenFileForWrite(string path)
+        {
+            return File.Open(path, FileMode.Append, System.IO.FileAccess.Write);
+        }
     }
 }

--- a/Ctlg.Filesystem/FilesystemService.cs
+++ b/Ctlg.Filesystem/FilesystemService.cs
@@ -76,5 +76,10 @@ namespace Ctlg.Filesystem
         {
             return Directory.GetCurrentDirectory();
         }
+
+        public Stream OpenFileForWrite(string path)
+        {
+            return File.Open(path, FileMode.Append, FileAccess.Write);
+        }
     }
 }

--- a/Ctlg.Service/Commands/BackupCommand.cs
+++ b/Ctlg.Service/Commands/BackupCommand.cs
@@ -37,7 +37,6 @@ namespace Ctlg.Service.Commands
 
             using (var backupWriter = BackupService.CreateWriter(config, Name, null, IsFastMode))
             {
-                backupWriter.AddComment($"ctlg {AppVersion.Version}");
                 backupWriter.AddComment($"FastMode={IsFastMode}");
                 foreach (var file in root.EnumerateFiles())
                 {

--- a/Ctlg.UnitTests/TestDoubles/VirtualFileSystem.cs
+++ b/Ctlg.UnitTests/TestDoubles/VirtualFileSystem.cs
@@ -140,6 +140,18 @@ namespace Ctlg.UnitTests.TestDoubles
             return content.GetReadStream();
         }
 
+        public Stream OpenFileForWrite(string path)
+        {
+            var content = GetFileContent(path);
+
+            var srcStream = content.GetReadStream();
+            var dstStream = content.GetWriteStream();
+
+            srcStream.CopyTo(dstStream);
+
+            return dstStream;
+        }
+
         public void SetFile(string path, string content, DateTime modifiedTime = default)
         {
             CreateDirectory(GetDirectoryName(path));


### PR DESCRIPTION
A workaround to prevent Sharing violation error when opening two zero-length files from exFAT drive when running on Mono in macOS.

Adds `OpenFileForWrite` method to `IFilesystemService.cs`.